### PR TITLE
Update mediawiki output

### DIFF
--- a/exe/prompt
+++ b/exe/prompt
@@ -83,22 +83,34 @@ elsif output_formatter == 'mediawiki'
 
   puts '== Records matched to Wikidata but not returned by SPARQL query =='
 
-  not_in_wikidata.each do |item_id|
-    morph_record = morph_records[wikidata_item_to_morph_id[item_id]]
-    puts "* {{Q|#{item_id}}} #{morph_record[:id]} #{morph_record[:name]}"
+  if not_in_wikidata.any?
+    not_in_wikidata.each do |item_id|
+      morph_record = morph_records[wikidata_item_to_morph_id[item_id]]
+      puts "* {{Q|#{item_id}}} #{morph_record[:id]} #{morph_record[:name]}"
+    end
+  else
+    puts 'None'
   end
 
   puts '== Records not in the Morph scraper, but in Wikidata =='
 
-  not_in_morph.each do |item_id|
-    puts "* {{Q|#{item_id}}}"
+  if not_in_morph.any?
+    not_in_morph.each do |item_id|
+      puts "* {{Q|#{item_id}}}"
+    end
+  else
+    puts 'None'
   end
 
   puts '== Records in the the Morph scraper not associated with a Wikidata item =='
 
-  morph_ids_without_wikidata.each do |morph_id|
-    morph_record = morph_records[morph_id]
-    puts "* #{morph_id} #{morph_record[:name]}"
+  if morph_ids_without_wikidata.any?
+    morph_ids_without_wikidata.each do |morph_id|
+      morph_record = morph_records[morph_id]
+      puts "* #{morph_id} #{morph_record[:name]}"
+    end
+  else
+    puts "None"
   end
 else
   abort "Unknown output formatter: #{output_formatter.inspect}"

--- a/exe/prompt
+++ b/exe/prompt
@@ -81,18 +81,22 @@ elsif output_formatter == 'mediawiki'
   puts scraper_sql
   puts '</syntaxhighlight>'
 
-  puts '== Records matched to Wikidata but not returned by SPARQL query =='
+  puts '== Items in external source but not returned by SPARQL query =='
 
-  if not_in_wikidata.any?
+  if not_in_wikidata.any? || morph_ids_without_wikidata.any?
     not_in_wikidata.each do |item_id|
       morph_record = morph_records[wikidata_item_to_morph_id[item_id]]
-      puts "* {{Q|#{item_id}}} #{morph_record[:id]} #{morph_record[:name]}"
+      puts "* #{morph_record[:name]} (#{morph_record[:id]}) Wikidata item: {{Q|#{item_id}}}"
+    end
+    morph_ids_without_wikidata.each do |morph_id|
+      morph_record = morph_records[morph_id]
+      puts "* #{morph_record[:name]} (#{morph_record[:id]})"
     end
   else
     puts 'None'
   end
 
-  puts '== Records not in the Morph scraper, but in Wikidata =='
+  puts '== Items returned by SPARQL query but not found in external source =='
 
   if not_in_morph.any?
     not_in_morph.each do |item_id|
@@ -100,17 +104,6 @@ elsif output_formatter == 'mediawiki'
     end
   else
     puts 'None'
-  end
-
-  puts '== Records in the the Morph scraper not associated with a Wikidata item =='
-
-  if morph_ids_without_wikidata.any?
-    morph_ids_without_wikidata.each do |morph_id|
-      morph_record = morph_records[morph_id]
-      puts "* #{morph_id} #{morph_record[:name]}"
-    end
-  else
-    puts "None"
   end
 else
   abort "Unknown output formatter: #{output_formatter.inspect}"

--- a/exe/prompt
+++ b/exe/prompt
@@ -74,6 +74,13 @@ if output_formatter == 'text'
 elsif output_formatter == 'mediawiki'
   puts 'SPARQL query used for this comparison:'
   puts "{{sparql|query=#{wikidata_list.sparql_query}\n}}"
+
+  puts "Scraper: https://morph.io/#{morph_scraper}\n"
+  puts 'SQL query used for this comparison:'
+  puts '<syntaxhighlight lang="sql">'
+  puts scraper_sql
+  puts '</syntaxhighlight>'
+
   puts '== Records matched to Wikidata but not returned by SPARQL query =='
 
   not_in_wikidata.each do |item_id|

--- a/exe/prompt
+++ b/exe/prompt
@@ -72,31 +72,33 @@ if output_formatter == 'text'
     puts "  #{morph_id} #{morph_record[:name]}"
   end
 elsif output_formatter == 'mediawiki'
-  puts 'SPARQL query used for this comparison:'
+  puts '== SPARQL query =='
   puts "{{sparql|query=#{wikidata_list.sparql_query}\n}}"
 
-  puts "Scraper: https://morph.io/#{morph_scraper}\n"
-  puts 'SQL query used for this comparison:'
+  puts '== External source =='
+  puts '=== Morph scraper ==='
+  puts "https://morph.io/#{morph_scraper}\n\n"
+  puts '=== SQL query ==='
   puts '<syntaxhighlight lang="sql">'
   puts scraper_sql
   puts '</syntaxhighlight>'
 
-  puts '== Items in external source but not returned by SPARQL query =='
+  puts '== Items in external source but not in SPARQL query =='
 
   if not_in_wikidata.any? || morph_ids_without_wikidata.any?
     not_in_wikidata.each do |item_id|
       morph_record = morph_records[wikidata_item_to_morph_id[item_id]]
-      puts "* #{morph_record[:name]} (#{morph_record[:id]}) Wikidata item: {{Q|#{item_id}}}"
+      puts "* [[#{item_id}|#{morph_record[:name]}]] ([#{morph_record[:source]} #{morph_record[:id]}])"
     end
     morph_ids_without_wikidata.each do |morph_id|
       morph_record = morph_records[morph_id]
-      puts "* #{morph_record[:name]} (#{morph_record[:id]})"
+      puts "* #{morph_record[:name]} ([#{morph_record[:source]} #{morph_record[:id]}])"
     end
   else
     puts 'None'
   end
 
-  puts '== Items returned by SPARQL query but not found in external source =='
+  puts '== Items in SPARQL query but not in external source =='
 
   if not_in_morph.any?
     not_in_morph.each do |item_id|

--- a/exe/prompt
+++ b/exe/prompt
@@ -73,7 +73,7 @@ if output_formatter == 'text'
   end
 elsif output_formatter == 'mediawiki'
   puts 'SPARQL query used for this comparison:'
-  puts "{{sparql|query=#{wikidata_list.sparql_query}}}"
+  puts "{{sparql|query=#{wikidata_list.sparql_query}\n}}"
   puts '== Records matched to Wikidata but not returned by SPARQL query =='
 
   not_in_wikidata.each do |item_id|


### PR DESCRIPTION
Tidy up the MediaWiki output when running with `PROMPT_OUTPUT_FORMATTER=mediawiki`.

- Fix bug with SPARQL query rendering
- Show scraper and SQL used for report
- Output "none" if there are no matches for a subsection

## Before merging

- [x] Once #9 is merged change the target branch of this pull request to `master`