### PR TITLE
Rewrite a given MediaWiki page based on template parameters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     compare_with_wikidata (0.1.0)
       everypolitician (>= 0.20)
+      mediawiki_api (~> 0.7)
       rest-client (~> 2.0)
 
 GEM
@@ -17,13 +18,25 @@ GEM
       require_all
     everypolitician-popolo (0.8.0)
       require_all
+    faraday (0.12.1)
+      multipart-post (>= 1.2, < 3)
+    faraday-cookie_jar (0.0.6)
+      faraday (>= 0.7.4)
+      http-cookie (~> 1.0.0)
+    faraday_middleware (0.11.0.1)
+      faraday (>= 0.7.4, < 1.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
+    mediawiki_api (0.7.1)
+      faraday (~> 0.9, >= 0.9.0)
+      faraday-cookie_jar (~> 0.0, >= 0.0.6)
+      faraday_middleware (~> 0.10, >= 0.10.0)
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     minitest (5.10.2)
+    multipart-post (2.0.0)
     netrc (0.11.0)
     parallel (1.11.2)
     parser (2.4.0.0)

--- a/TEMPLATE-BASED-REWRITER.md
+++ b/TEMPLATE-BASED-REWRITER.md
@@ -1,0 +1,123 @@
+# Usage
+
+This gem provides a class,
+`MediaWikiRewriteFromTemplate::WikiPage`, which helps you to
+programmatically rewrite MediaWiki pages based on the parameters
+of a template tag (or template tags) in that page. (This is a
+model used by the
+[Listeria](https://tools.wmflabs.org/listeria/) bot, for
+example.)
+
+For example, suppose you created a page on Wikidata with the
+following wikitext:
+
+```
+{{Fibonacci
+|max_fib=10
+}}
+
+<!-- OUTPUT BEGIN -->
+<!-- OUTPUT END -->
+```
+
+... at https://www.wikidata.org/wiki/User:Mhl20/Fibonnacci_test
+
+You could then use the following code to rewrite that page to
+include the Fibonacci numbers less than or equal to `max_fib`
+using:
+
+
+```
+require 'mediawiki_rewrite_from_template'
+
+class FibonacciRewriter
+  def rewrite(template_name:, template_parameters:, old_wikitext:)
+    if template_name == 'Fibonacci'
+      limit = Integer(template_parameters[:max_fib])
+      "=== Some Fibonacci numbers ===\n:{| class=\"wikitable\"\n" +
+        wikitext_rows(limit) +
+        "|}"
+    end
+  end
+
+  def wikitext_rows(limit)
+    fibs = fibonacci_numbers(limit)
+    "|-\n" + 0.upto(fibs.length - 1).map { |f| "| ''F''<sub>#{f}</sub>\n" }.join('') +
+      "|-\n" + fibs.map { |n| "| #{n}\n" }.join('')
+  end
+
+  def fibonacci_numbers(limit)
+    numbers = []
+    i, j = 0, 1
+    while i <= limit
+      numbers << i
+      i, j = j, i + j
+    end
+    numbers
+  end
+end
+
+wiki_page = MediaWikiRewriteFromTemplate::WikiPage.new(
+  username: ENV['WIKI_USERNAME'],
+  password: ENV['WIKI_PASSWORD'],
+  site: 'www.wikidata.org',
+  title: 'User:Mhl20/Fibonnacci test'
+)
+
+wiki_page.rewrite_and_put(FibonacciRewriter.new)
+```
+
+The result of this code would be that the page would be
+rewritten to have the following wikitext:
+
+```
+{{Fibonacci
+|max_fib=10
+}}
+
+<!-- OUTPUT BEGIN -->
+=== Some Fibonacci numbers ===
+:{| class="wikitable"
+|-
+| ''F''<sub>0</sub>
+| ''F''<sub>1</sub>
+| ''F''<sub>2</sub>
+| ''F''<sub>3</sub>
+| ''F''<sub>4</sub>
+| ''F''<sub>5</sub>
+| ''F''<sub>6</sub>
+|-
+| 0
+| 1
+| 1
+| 2
+| 3
+| 5
+| 8
+|}
+<!-- OUTPUT END -->
+```
+
+The object you pass to the `rewrite_and_put` method should have
+a method called rewrite that meets the following criteria:
+
+* It should take the following keyword arguments:
+    * `template_name`: the name of the template (between `{{` and
+      the first `|` or `}}` in the page.
+    * `old_wikitext`: what was between the `<!-- OUTPUT BEGIN -->`
+      and `<!-- OUTPUT END -->` HTML comments after the template
+      tag.
+    * `template_parameters`: the named parameters in the
+      template tag as a `Hash` with symbolized keys. e.g. in the
+      example above, that would be: `{:max_fib => '10'}`
+
+If this method throws an exception, returns `nil` or returns a
+string equal to `old_wikitext`, no change will be made to the
+text between the `<!-- OUTPUT BEGIN -->` and `<!-- OUTPUT END
+-->` HTML comments.  Otherwise, the page will be rewritten with
+the string returned by `rewrite` replacing the text between
+those comments.
+
+There can be multiple such templates followed by the special
+HTML comments on a single page, and `rewrite` will be applied to
+all of them.

--- a/compare_with_wikidata.gemspec
+++ b/compare_with_wikidata.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'rest-client', '~> 2.0'
   spec.add_runtime_dependency 'everypolitician', '>= 0.20'
+  spec.add_runtime_dependency 'mediawiki_api', '~> 0.7'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/compare_with_wikidata.rb
+++ b/lib/compare_with_wikidata.rb
@@ -3,6 +3,7 @@ require 'compare_with_wikidata/version'
 require 'compare_with_wikidata/membership_list/morph'
 require 'compare_with_wikidata/membership_list/wikidata'
 require 'compare_with_wikidata/mapping/ep_identifier_to_wikidata'
+require 'compare_with_wikidata/wiki_page'
 
 module CompareWithWikidata
   # Your code goes here...

--- a/lib/compare_with_wikidata.rb
+++ b/lib/compare_with_wikidata.rb
@@ -4,6 +4,7 @@ require 'compare_with_wikidata/membership_list/morph'
 require 'compare_with_wikidata/membership_list/wikidata'
 require 'compare_with_wikidata/mapping/ep_identifier_to_wikidata'
 require 'compare_with_wikidata/wiki_page'
+require 'compare_with_wikidata/rewriting/template_section'
 
 module CompareWithWikidata
   # Your code goes here...

--- a/lib/compare_with_wikidata/rewriting/template_section.rb
+++ b/lib/compare_with_wikidata/rewriting/template_section.rb
@@ -1,0 +1,9 @@
+module CompareWithWikidata
+  class TemplateSection
+    def initialize(original_wikitext)
+      @original_wikitext = original_wikitext
+    end
+
+    attr_accessor :original_wikitext
+  end
+end

--- a/lib/compare_with_wikidata/rewriting/template_section.rb
+++ b/lib/compare_with_wikidata/rewriting/template_section.rb
@@ -25,6 +25,23 @@ module CompareWithWikidata
       end.to_h
     end
 
+    def dup_with(new_content:)
+      TemplateSection.new(
+        original_wikitext: '{{%<template_name>s%<parameters>s}}' \
+                           "%<between>s%<content_begin>s\n#{new_content}\n" \
+                           '%<content_end>s' % top_level_split
+      )
+    end
+
+    def rewrite(rewriter)
+      dup_with(
+        new_content: rewriter.rewrite(
+          old_content: top_level_split[:content],
+          parameters:  named_parameters
+        )
+      )
+    end
+
     attr_accessor :original_wikitext
 
     private
@@ -43,7 +60,16 @@ module CompareWithWikidata
     TEMPLATE_RE_NO_GROUPS = Regexp.new(TEMPLATE_RE.to_s.gsub(/\?<\w+>/, '?:'))
 
     def top_level_split
-      @top_level_split ||= TEMPLATE_RE.match(original_wikitext)
+      # The version of Ruby we're using at the moment (2.3) doesn't
+      # have Hash.named_captures yet, which would make this a bit
+      # simpler.
+      @top_level_split ||= top_level_split_matchdata.names.map(&:to_sym).zip(
+        top_level_split_matchdata.captures
+      ).to_h
+    end
+
+    def top_level_split_matchdata
+      @top_level_split_matchdata ||= TEMPLATE_RE.match(original_wikitext)
     end
   end
 end

--- a/lib/compare_with_wikidata/rewriting/template_section.rb
+++ b/lib/compare_with_wikidata/rewriting/template_section.rb
@@ -1,9 +1,47 @@
 module CompareWithWikidata
   class TemplateSection
-    def initialize(original_wikitext)
+    def initialize(original_wikitext:)
       @original_wikitext = original_wikitext
     end
 
+    def template_name
+      top_level_split[:template_name].strip
+    end
+
+    def all_parameters
+      # This returns all parameters, including anonymous, numbered and
+      # named parameters. (Though we only handle named parameters at
+      # the moment.)
+      top_level_split[:parameters].split('|').select do |s|
+        s.strip!
+        s.empty? ? nil : s
+      end
+    end
+
+    def named_parameters
+      all_parameters.map do |p|
+        m = /(.*?)=(.*)/m.match(p)
+        [m[1].strip.to_sym, m[2]]
+      end.to_h
+    end
+
     attr_accessor :original_wikitext
+
+    private
+
+    TEMPLATE_RE = /
+        \{\{
+        (?<template_name>[^\|]*)
+        (?<parameters>.*?)
+        \}\}
+        (?<between>.*?)
+        (?<content_begin><!--\ [\w\ ]*OUTPUT\ BEGIN\ -->)
+        (?<content>.*?)
+        (?<content_end><!--\ [\w\ ]*OUTPUT\ END\ -->)
+    /xm
+
+    def top_level_split
+      @top_level_split ||= TEMPLATE_RE.match(original_wikitext)
+    end
   end
 end

--- a/lib/compare_with_wikidata/rewriting/template_section.rb
+++ b/lib/compare_with_wikidata/rewriting/template_section.rb
@@ -40,6 +40,8 @@ module CompareWithWikidata
         (?<content_end><!--\ [\w\ ]*OUTPUT\ END\ -->)
     /xm
 
+    TEMPLATE_RE_NO_GROUPS = Regexp.new(TEMPLATE_RE.to_s.gsub(/\?<\w+>/, '?:'))
+
     def top_level_split
       @top_level_split ||= TEMPLATE_RE.match(original_wikitext)
     end

--- a/lib/compare_with_wikidata/wiki_page.rb
+++ b/lib/compare_with_wikidata/wiki_page.rb
@@ -13,6 +13,18 @@ module CompareWithWikidata
       @wikitext ||= client.get_wikitext(title).body
     end
 
+    def template_sections
+      section_re = /
+        \{\{Politician\ scraper\ comparison
+        .*?
+        <!--\ COMPARISON\ OUTPUT\ BEGIN\ -->
+        .*?
+        <!--\ COMPARISON\ OUTPUT\ END\ -->/xm
+      wikitext.scan(section_re).map do |matched_text|
+        TemplateSection.new(matched_text)
+      end
+    end
+
     private
 
     attr_accessor :username, :password, :title, :client_class

--- a/lib/compare_with_wikidata/wiki_page.rb
+++ b/lib/compare_with_wikidata/wiki_page.rb
@@ -1,0 +1,26 @@
+require 'mediawiki_api'
+
+module CompareWithWikidata
+  class WikiPage
+    def initialize(username:, password:, title:, client_class: nil)
+      @username = username
+      @password = password
+      @title = title
+      @client_class = client_class || MediawikiApi::Client
+    end
+
+    def wikitext
+      @wikitext ||= client.get_wikitext(title).body
+    end
+
+    private
+
+    attr_accessor :username, :password, :title, :client_class
+
+    def client
+      @client ||= client_class.new('https://www.wikidata.org/w/api.php').tap do |c|
+        c.log_in(username, password)
+      end
+    end
+  end
+end

--- a/lib/compare_with_wikidata/wiki_page.rb
+++ b/lib/compare_with_wikidata/wiki_page.rb
@@ -34,6 +34,13 @@ module CompareWithWikidata
       @non_template_sections ||= wikitext.split(TemplateSection::TEMPLATE_RE_NO_GROUPS)
     end
 
+    def rewrite(rewriter)
+      rewritten_template_sections = template_sections.map do |template_section|
+        template_section.rewrite(rewriter)
+      end
+      reassemble_page(rewritten_template_sections)
+    end
+
     private
 
     attr_accessor :username, :password, :title, :client_class

--- a/lib/compare_with_wikidata/wiki_page.rb
+++ b/lib/compare_with_wikidata/wiki_page.rb
@@ -21,7 +21,7 @@ module CompareWithWikidata
         .*?
         <!--\ COMPARISON\ OUTPUT\ END\ -->/xm
       wikitext.scan(section_re).map do |matched_text|
-        TemplateSection.new(matched_text)
+        TemplateSection.new(original_wikitext: matched_text)
       end
     end
 

--- a/lib/compare_with_wikidata/wiki_page.rb
+++ b/lib/compare_with_wikidata/wiki_page.rb
@@ -41,6 +41,17 @@ module CompareWithWikidata
       reassemble_page(rewritten_template_sections)
     end
 
+    def rewrite_and_put(rewriter)
+      new_wikitext = rewrite(rewriter)
+      if new_wikitext == wikitext
+        warn("Warning: after rewriting, the content of #{title} remained the same")
+        self
+      else
+        client.edit(title: title, text: new_wikitext)
+        self.class.new(username: username, password: password, title: title, client_class: client_class)
+      end
+    end
+
     private
 
     attr_accessor :username, :password, :title, :client_class

--- a/test/template_section_test.rb
+++ b/test/template_section_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+describe 'TemplateSection' do
+  let(:template_section) do
+    CompareWithWikidata::TemplateSection.new(
+      original_wikitext: '{{Politician scraper comparison
+|foo=43
+|bar=Woolly Mountain Tapir
+}}
+
+<!-- COMPARISON OUTPUT BEGIN -->
+
+<!-- COMPARISON OUTPUT END -->'
+    )
+  end
+
+  it 'returns a Hash of parameters' do
+    template_section.named_parameters.must_equal(foo: '43', bar: 'Woolly Mountain Tapir')
+  end
+
+  it 'returns the template name' do
+    template_section.template_name.must_equal('Politician scraper comparison')
+  end
+end

--- a/test/template_section_test.rb
+++ b/test/template_section_test.rb
@@ -21,4 +21,24 @@ describe 'TemplateSection' do
   it 'returns the template name' do
     template_section.template_name.must_equal('Politician scraper comparison')
   end
+
+  it 'can be rewritten' do
+    class TestRewriter
+      def rewrite(parameters:, **)
+        "The output is now #{parameters[:foo]}"
+      end
+    end
+    rewritten = template_section.rewrite(TestRewriter.new)
+    rewritten.original_wikitext.must_equal(
+      '{{Politician scraper comparison
+|foo=43
+|bar=Woolly Mountain Tapir
+}}
+
+<!-- COMPARISON OUTPUT BEGIN -->
+The output is now 43
+<!-- COMPARISON OUTPUT END -->'
+    )
+    rewritten.original_wikitext.wont_equal(template_section.original_wikitext)
+  end
 end

--- a/test/wikipage_test.rb
+++ b/test/wikipage_test.rb
@@ -7,23 +7,79 @@ class FakeClient
 
   def log_in(*); end
 
-  def get_wikitext(title)
-    FakeResponse.new('Foo bar')
+  SAMPLE_WIKITEXT = 'Hi, here is some introductory text.
+
+Now let\'s have a recognized template:
+
+{{Politician scraper comparison
+|foo=43
+|bar=Woolly Mountain Tapir
+}}
+
+<!-- COMPARISON OUTPUT BEGIN -->
+
+<!-- COMPARISON OUTPUT END -->
+
+And some other text here before a new template:
+
+{{Politician scraper comparison
+|quux=13
+|bar=Horse
+}}
+
+<!-- COMPARISON OUTPUT BEGIN -->
+
+<!-- COMPARISON OUTPUT END -->
+
+Now some trailing text.'.freeze
+
+  def get_wikitext(_title)
+    FakeResponse.new(SAMPLE_WIKITEXT)
   end
 end
 
 describe 'WikiPage' do
-  it 'can be initialized with a username, password and title' do
+  let(:wiki_page) do
     CompareWithWikidata::WikiPage.new(
-      username: 'john', password: 's3krit', title: 'Some Wiki page'
+      username: 'john', password: 's3krit', title: 'Some Wiki page', client_class: FakeClient
     )
   end
 
   it 'can return the wikitext for a page' do
+    wiki_page.wikitext.must_match(/^Hi, here is some.*trailing text.$/m)
+  end
 
-    wiki_page = CompareWithWikidata::WikiPage.new(
-      username: 'john', password: 's3krit', title: 'Some Wiki page', client_class: FakeClient
+  it 'returns two template sections' do
+    wiki_page.template_sections.length.must_equal(2)
+  end
+
+  it 'returns template sections of the expected class' do
+    wiki_page.template_sections[0].class.must_equal(CompareWithWikidata::TemplateSection)
+  end
+
+  it 'gives the right content to the first TemplateSection' do
+    wiki_page.template_sections[0].original_wikitext.must_equal(
+      '{{Politician scraper comparison
+|foo=43
+|bar=Woolly Mountain Tapir
+}}
+
+<!-- COMPARISON OUTPUT BEGIN -->
+
+<!-- COMPARISON OUTPUT END -->'
     )
-    wiki_page.wikitext.must_equal('Foo bar')
+  end
+
+  it 'gives the right content to the second TemplateSection' do
+    wiki_page.template_sections[1].original_wikitext.must_equal(
+      '{{Politician scraper comparison
+|quux=13
+|bar=Horse
+}}
+
+<!-- COMPARISON OUTPUT BEGIN -->
+
+<!-- COMPARISON OUTPUT END -->'
+    )
   end
 end

--- a/test/wikipage_test.rb
+++ b/test/wikipage_test.rb
@@ -17,7 +17,7 @@ Now let\'s have a recognized template:
 }}
 
 <!-- COMPARISON OUTPUT BEGIN -->
-
+Old content of the first section.
 <!-- COMPARISON OUTPUT END -->
 
 And some other text here before a new template:
@@ -28,7 +28,7 @@ And some other text here before a new template:
 }}
 
 <!-- COMPARISON OUTPUT BEGIN -->
-
+Old content of the second section.
 <!-- COMPARISON OUTPUT END -->
 
 Now some trailing text.'.freeze
@@ -65,7 +65,7 @@ describe 'WikiPage' do
 }}
 
 <!-- COMPARISON OUTPUT BEGIN -->
-
+Old content of the first section.
 <!-- COMPARISON OUTPUT END -->'
     )
   end
@@ -78,7 +78,7 @@ describe 'WikiPage' do
 }}
 
 <!-- COMPARISON OUTPUT BEGIN -->
-
+Old content of the second section.
 <!-- COMPARISON OUTPUT END -->'
     )
   end

--- a/test/wikipage_test.rb
+++ b/test/wikipage_test.rb
@@ -103,4 +103,48 @@ Second.
 Now some trailing text.'
     )
   end
+
+  it 'can be rewritten with a "rewriter" object' do
+    class TestRewriter
+      def rewrite(old_content:, parameters:)
+        "Preserving the old content:\n#{old_content}\n" \
+        "In this template, foo is '#{parameters[:foo]}' and quux is '#{parameters[:quux]}'"
+      end
+    end
+    wiki_page.rewrite(TestRewriter.new).must_equal(
+      'Hi, here is some introductory text.
+
+Now let\'s have a recognized template:
+
+{{Politician scraper comparison
+|foo=43
+|bar=Woolly Mountain Tapir
+}}
+
+<!-- COMPARISON OUTPUT BEGIN -->
+Preserving the old content:
+
+Old content of the first section.
+
+In this template, foo is \'43\' and quux is \'\'
+<!-- COMPARISON OUTPUT END -->
+
+And some other text here before a new template:
+
+{{Politician scraper comparison
+|quux=13
+|bar=Horse
+}}
+
+<!-- COMPARISON OUTPUT BEGIN -->
+Preserving the old content:
+
+Old content of the second section.
+
+In this template, foo is \'\' and quux is \'13\'
+<!-- COMPARISON OUTPUT END -->
+
+Now some trailing text.'
+    )
+  end
 end

--- a/test/wikipage_test.rb
+++ b/test/wikipage_test.rb
@@ -82,4 +82,25 @@ describe 'WikiPage' do
 <!-- COMPARISON OUTPUT END -->'
     )
   end
+
+  it 'can be reassembled with replacement template sections' do
+    wiki_page.reassemble_page(
+      [
+        CompareWithWikidata::TemplateSection.new(original_wikitext: 'FIRST!'),
+        CompareWithWikidata::TemplateSection.new(original_wikitext: 'Second.'),
+      ]
+    ).must_equal(
+      'Hi, here is some introductory text.
+
+Now let\'s have a recognized template:
+
+FIRST!
+
+And some other text here before a new template:
+
+Second.
+
+Now some trailing text.'
+    )
+  end
 end

--- a/test/wikipage_test.rb
+++ b/test/wikipage_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+FakeResponse = Struct.new(:body)
+
+class FakeClient
+  def initialize(*); end
+
+  def log_in(*); end
+
+  def get_wikitext(title)
+    FakeResponse.new('Foo bar')
+  end
+end
+
+describe 'WikiPage' do
+  it 'can be initialized with a username, password and title' do
+    CompareWithWikidata::WikiPage.new(
+      username: 'john', password: 's3krit', title: 'Some Wiki page'
+    )
+  end
+
+  it 'can return the wikitext for a page' do
+
+    wiki_page = CompareWithWikidata::WikiPage.new(
+      username: 'john', password: 's3krit', title: 'Some Wiki page', client_class: FakeClient
+    )
+    wiki_page.wikitext.must_equal('Foo bar')
+  end
+end


### PR DESCRIPTION
[This isn't quite ready yet; e.g. there are a few tests I'd like to add, and the prompt script hasn't been updated to use this. It's probably still worth getting comments on at this stage.]

One thing to consider is whether all this new code should be in a separate gem, since it's quite a generic way of rewriting MediaWiki pages based on template parameters, and not really specific to this application.

As an example of usage, You could do:

```ruby
wiki_page = CompareWithWikidata::WikiPage.new(
  username: ENV['WIKI_USERNAME'],
  password: ENV['WIKI_PASSWORD'],
  title:   'User:Mhl20/test template'
)

class ExampleRewriter
  def rewrite(old_content:, parameters:)
    "Preserving the old content:\n#{old_content}\n" \
    "The animal parameter was: '#{parameters[:animal]}'"
  end
end

wiki_page.rewrite_and_put(ExampleRewriter.new)
```

This has been run twice on: https://www.wikidata.org/wiki/User:Mhl20/test_template for example.