### PR TITLE
Move daff logic into separate class and add tests

### DIFF
--- a/lib/compare_with_wikidata/comparison.rb
+++ b/lib/compare_with_wikidata/comparison.rb
@@ -1,0 +1,60 @@
+require 'compare_with_wikidata/diff_row'
+
+require 'daff'
+
+module CompareWithWikidata
+  class Comparison
+    def initialize(sparql_items:, csv_items:, columns:)
+      @sparql_items = sparql_items
+      @csv_items = csv_items
+      @columns = columns
+    end
+
+    def headers
+      daff_results.first
+    end
+
+    def diff_rows
+      @diff_rows ||= rows.map { |row| DiffRow.new(headers: headers, row: row) }
+    end
+
+    private
+
+    attr_reader :sparql_items, :csv_items, :columns
+
+    def daff_sparql_items
+      [columns, *sparql_items.map { |r| r.values_at(*columns) }]
+    end
+
+    def daff_csv_items
+      [columns, *csv_items.map { |r| r.values_at(*columns) }]
+    end
+
+    def daff_results
+      @daff_results ||= daff_diff(daff_sparql_items, daff_csv_items)
+    end
+
+    # Daff diff rows, excluding moved rows (:)
+    def rows
+      daff_results.drop(1).reject { |r| r.first == ':' }
+    end
+
+    def daff_diff(data1, data2)
+      t1 = Daff::TableView.new(data1)
+      t2 = Daff::TableView.new(data2)
+
+      alignment = Daff::Coopy.compare_tables(t1, t2).align
+
+      data_diff = []
+      table_diff = Daff::TableView.new(data_diff)
+
+      flags = Daff::CompareFlags.new
+      # We don't want any context in the resulting diff
+      flags.unchanged_context = 0
+      highlighter = Daff::TableDiff.new(alignment, flags)
+      highlighter.hilite(table_diff)
+
+      data_diff
+    end
+  end
+end

--- a/templates/comparison.erb
+++ b/templates/comparison.erb
@@ -3,6 +3,6 @@ Please see the [[../|main prompt page]].
 </noinclude>
 <includeonly>
 {{/header_template}}
-<%= diff_rows.map(&:wikitext).join("\n") %>
+<%= comparison.diff_rows.map(&:wikitext).join("\n") %>
 {{/footer_template}}
 </includeonly>

--- a/templates/header_template.erb
+++ b/templates/header_template.erb
@@ -1,5 +1,5 @@
 {|class="wikitable sortable"
-<% headers.each do |header| -%>
+<% comparison.headers.each do |header| -%>
 ! <%= header %>
 <% end -%>
 |-

--- a/templates/row_added.erb
+++ b/templates/row_added.erb
@@ -1,4 +1,4 @@
 |-
-<% headers.each do |header| -%>
+<% comparison.headers.each do |header| -%>
 | {{{<%= header %>}}}
 <% end -%>

--- a/templates/row_modified.erb
+++ b/templates/row_modified.erb
@@ -1,4 +1,4 @@
 |-
-<% headers.each do |header| -%>
+<% comparison.headers.each do |header| -%>
 | {{{<%= header %>}}}
 <% end -%>

--- a/templates/row_removed.erb
+++ b/templates/row_removed.erb
@@ -1,4 +1,4 @@
 |-
-<% headers.each do |header| -%>
+<% comparison.headers.each do |header| -%>
 | {{{<%= header %>}}}
 <% end -%>

--- a/templates/stats.erb
+++ b/templates/stats.erb
@@ -1,7 +1,7 @@
 {{/stats_template
-| removed=<%= diff_rows.count(&:removal?) %>
-| added=<%= diff_rows.count(&:addition?) %>
-| modified=<%= diff_rows.count(&:modification?) %>
+| removed=<%= comparison.diff_rows.count(&:removal?) %>
+| added=<%= comparison.diff_rows.count(&:addition?) %>
+| modified=<%= comparison.diff_rows.count(&:modification?) %>
 | sparql_count=<%= wikidata_records.size %>
 | csv_count=<%= external_csv.size %>
 }}

--- a/test/compare_with_wikidata/comparison_test.rb
+++ b/test/compare_with_wikidata/comparison_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+describe CompareWithWikidata::Comparison do
+  let(:sparql_items) { [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }] }
+  let(:csv_items) { [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }, { id: 3, name: 'Charlie' }] }
+  subject { CompareWithWikidata::Comparison.new(sparql_items: sparql_items, csv_items: csv_items, columns: %i[id name]) }
+
+  describe '#headers' do
+
+    it 'returns the headers for the daff comparison' do
+      subject.headers.must_equal ['@@', :id, :name]
+    end
+  end
+
+  describe '#diff_rows' do
+    it 'returns the correct number of rows' do
+      subject.diff_rows.size.must_equal 1
+    end
+
+    it 'returns the expected number of DiffRow instances' do
+      row = subject.diff_rows.first
+      row.class.must_equal CompareWithWikidata::DiffRow
+    end
+  end
+end


### PR DESCRIPTION
This moves the code for interacting with daff into a `Comparison` class. I've also added some (_very_ basic) tests for this new class.

## Notes to reviewer

This refactoring was prompted by wanting to add a regression test when fixing #65. Because the code I wanted to add a regression test for was [deep in `CompareWithWikidata::DiffOutputGenerator#run!`](https://github.com/everypolitician/compare_with_wikidata/blob/master/lib/compare_with_wikidata.rb#L41-L43) adding a test would have meant writing a full end to end integration test. So this pull request is in the spirit of "make the change easy and then make the easy change".

Should unblock #65 