### PR TITLE
Integrate with wikidata

### DIFF
--- a/compare_with_wikidata.gemspec
+++ b/compare_with_wikidata.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rest-client', '~> 2.0'
   spec.add_runtime_dependency 'everypolitician', '>= 0.20'
   spec.add_runtime_dependency 'daff', '>= 1.3'
+  spec.add_runtime_dependency 'mediawiki-page-replaceable_content'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/exe/compare_with_wikidata
+++ b/exe/compare_with_wikidata
@@ -2,6 +2,9 @@
 require 'bundler/setup'
 require 'daff'
 require 'csv'
+require 'erb'
+require 'mediawiki/client'
+require 'mediawiki/page'
 
 require 'compare_with_wikidata'
 
@@ -31,37 +34,44 @@ def csv_from_url(file_or_url)
   end
 end
 
+WIKI_TEMPLATE_NAME = 'Compare Wikidata with CSV'.freeze
+WIKI_USERNAME = ENV['WIKI_USERNAME']
+WIKI_PASSWORD = ENV['WIKI_PASSWORD']
+
 if ARGV.size != 2
-  abort "Usage: #{$PROGRAM_NAME} SPARQL_QUERY CSV_FILE_OR_URL
-e.g. prompt 'SELECT (STRAFTER(STR(?item), STR(wd:)) AS ?id) (STRAFTER(STR(?officeholder), STR(wd:)) AS ?holder_id)
-  WHERE {
-    ?item wdt:P31 wd:Q6256 .
-    OPTIONAL {
-      ?item wdt:P1313 ?office .
-      OPTIONAL { ?office wdt:P1308 ?officeholder . }
-    }
-  }
-ORDER BY ?id' \\
-https://gist.githubusercontent.com/chrismytton/ddb3974b056f92051370a28b27168bbe/raw/4d2286134a6f8a9a47fbeb546069535eff589ca3/heads-of-government-morph.csv
+  abort "Usage: #{$PROGRAM_NAME} MEDIAWIKI_SITE PAGE_TITLE
+e.g. compare_with_wikidata www.wikidata.org 'User:Mhl20/Fibonacci test'
 "
 end
 
-sparql_query, csv_file_or_url = ARGV
-output_formatter = ENV.fetch('PROMPT_OUTPUT_FORMATTER', 'text')
+mediawiki_site, page_title = ARGV
+
+client = MediaWiki::Client.new(
+  site:     mediawiki_site,
+  username: WIKI_USERNAME,
+  password: WIKI_PASSWORD
+)
+
+section = MediaWiki::Page::ReplaceableContent.new(
+  client:   client,
+  title:    page_title,
+  template: WIKI_TEMPLATE_NAME
+)
+
+sparql_query = section.params[:sparql]
+csv_url = section.params[:csv_url]
 
 wikidata_records = CompareWithWikidata::MembershipList::Wikidata.new(sparql_query: sparql_query).to_a
 
-external_csv = csv_from_url(csv_file_or_url)
+external_csv = csv_from_url(csv_url)
 
 headers, *rows = daff_diff(wikidata_records, external_csv)
+template = ERB.new(File.read(File.join(__dir__, '..', 'templates/mediawiki.erb')), nil, '-')
+wikitext = template.result(binding)
 
-if output_formatter == 'text'
-  CSV do |csv|
-    csv << headers
-    rows.each { |row| csv << row }
-  end
-elsif output_formatter == 'mediawiki'
-  require 'erb'
-  template = ERB.new(File.read(File.join(__dir__, '..', 'templates/mediawiki.erb')), nil, '-')
-  puts template.result(binding)
+if ENV.key?('DEBUG')
+  puts wikitext
+else
+  section.replace_output(wikitext, "Update templates at #{DateTime.now}")
+  puts "Done: Updated #{page_title} on #{mediawiki_site}"
 end

--- a/templates/mediawiki.erb
+++ b/templates/mediawiki.erb
@@ -1,12 +1,12 @@
 == SPARQL query ==
 
 {{sparql
-|query=<%= sparql_query.gsub('|', '{{!}}')%>
+|query=<%= sparql_query.gsub('|', '{{!}}') %>
 }}
 
 == External source ==
 
-<%= csv_file_or_url %>
+<%= csv_url %>
 
 == Stats ==
 


### PR DESCRIPTION
This uses the [mediawiki-page-replaceable_content](https://github.com/everypolitician/mediawiki-page-replaceable_content) library to interact with Wikidata directly.

Fixes #18 

## Notes to merger

Please complete the following before merging:

- [x] Change base branch to `master` once #28 has been merged.