### PR TITLE
Allow user to supply templates

### DIFF
--- a/exe/compare_with_wikidata
+++ b/exe/compare_with_wikidata
@@ -66,6 +66,7 @@ wikidata_records = CompareWithWikidata::MembershipList::Wikidata.new(sparql_quer
 external_csv = csv_from_url(csv_url)
 
 headers, *rows = daff_diff(wikidata_records, external_csv)
+diff_rows = rows.map { |row| CompareWithWikidata::DiffRow.new(headers: headers, row: row, params: section.params) }
 template = ERB.new(File.read(File.join(__dir__, '..', 'templates/mediawiki.erb')), nil, '-')
 wikitext = template.result(binding)
 

--- a/lib/compare_with_wikidata.rb
+++ b/lib/compare_with_wikidata.rb
@@ -1,5 +1,6 @@
 require 'compare_with_wikidata/version'
 
+require 'compare_with_wikidata/diff_row'
 require 'compare_with_wikidata/membership_list/wikidata'
 
 module CompareWithWikidata

--- a/lib/compare_with_wikidata/diff_row.rb
+++ b/lib/compare_with_wikidata/diff_row.rb
@@ -1,0 +1,55 @@
+module CompareWithWikidata
+  class DiffRow
+    CUSTOM_TEMPLATE_MAPPING = {
+      '+++' => :row_added_template,
+      '---' => :row_removed_template,
+      '->'  => :row_modified_template,
+    }.freeze
+
+    def initialize(headers:, row:, params:)
+      @headers = headers
+      @row = row
+      @params = params
+    end
+
+    def wikitext
+      if custom_template
+        "{{#{custom_template}|#{template_params}}}"
+      else
+        row.map { |c| "| #{c.to_s.gsub(/Q(\d+)/, '{{Q|\\1}}').gsub('->', ' &rarr; ')}" }.join("\n") + "\n|-\n"
+      end
+    end
+
+    def addition?
+      change_type == '+++'
+    end
+
+    def removal?
+      change_type == '---'
+    end
+
+    def modification?
+      change_type == '->'
+    end
+
+    private
+
+    attr_reader :headers, :row, :params
+
+    def custom_template
+      params[CUSTOM_TEMPLATE_MAPPING[change_type]]
+    end
+
+    def row_as_hash
+      headers.zip(row).to_h
+    end
+
+    def change_type
+      row_as_hash['@@']
+    end
+
+    def template_params
+      row_as_hash.to_a.map { |v| v.join('=') }.join('|')
+    end
+  end
+end

--- a/templates/mediawiki.erb
+++ b/templates/mediawiki.erb
@@ -10,23 +10,26 @@
 
 == Stats ==
 
-* Items only found in SPARQL (<code>---</code> in the first column): <%= rows.count { |r| r.first == '---' } %>
-* Items only found in CSV (<code>+++</code> in the first column): <%= rows.count { |r| r.first == '+++' } %>
-* Items that differ between sources (&rarr; in the first column): <%= rows.count { |r| r.first == '->' } %>
+* Items only found in SPARQL (<code>---</code> in the first column): <%= diff_rows.count(&:removal?) %>
+* Items only found in CSV (<code>+++</code> in the first column): <%= diff_rows.count(&:addition?) %>
+* Items that differ between sources (&rarr; in the first column): <%= diff_rows.count(&:modification?) %>
 * Total Wikidata items returned by SPARQL query: <%= wikidata_records.size %>
 * Total Rows in CSV: <%= external_csv.size %>
 
 == Comparison ==
 
+<% if section.params[:header_template] %>
+{{<%= section.params[:header_template] %>}}
+<% else %>
 {|class="wikitable"
 <% headers.each do |header| -%>
 | <%= header %>
 <% end -%>
 |-
-<% rows.each do |row| -%>
-<% row.each do |item| -%>
-| <%= item.to_s.gsub(/Q(\d+)/, '{{Q|\\1}}').gsub('->', ' &rarr; ') %>
 <% end -%>
-|-
-<% end -%>
+<%= diff_rows.map(&:wikitext).join("\n") %>
+<% if section.params[:footer_template] %>
+{{<%= section.params[:footer_template] %>}}
+<% else %>
 |}
+<% end %>


### PR DESCRIPTION
This adds some extra template parameters which can be used to specify custom templates to be used when rendering a prompt page.

You can see custom templates in action [on this Heads of Government report](https://www.wikidata.org/w/index.php?title=User:Chris_Mytton/sandbox/daff_heads_of_government&oldid=531283823), where I've used them to hide the additions and removals so it only shows the modifications.

Fixes #16 

## Notes to merger

Please complete the following before merging:

- [x] Change base branch to `master` once #26 has been merged.