### PR TITLE
Separate template parameters for SPARQL and CSV values

### DIFF
--- a/lib/compare_with_wikidata/diff_row.rb
+++ b/lib/compare_with_wikidata/diff_row.rb
@@ -49,7 +49,26 @@ module CompareWithWikidata
     end
 
     def template_params
-      row_as_hash.to_a.map { |v| v.join('=') }.join('|')
+      (row_as_hash.take(1) + row_as_hash.to_a.drop(1).flat_map do |k, v|
+        if modification?
+          if v.include?('->')
+            sparql_v, csv_v = v.split('->')
+          else
+            sparql_v, csv_v = v, v
+          end
+        elsif addition?
+          sparql_v = nil
+          csv_v = v
+        elsif removal?
+          sparql_v = v
+          csv_v = nil
+        end
+        [
+          [k, v],
+          ["#{k}_sparql", sparql_v],
+          ["#{k}_csv", csv_v]
+        ]
+      end).map { |v| v.join('=') }.join('|')
     end
   end
 end

--- a/lib/compare_with_wikidata/diff_row/cell.rb
+++ b/lib/compare_with_wikidata/diff_row/cell.rb
@@ -1,0 +1,58 @@
+module CompareWithWikidata
+  class DiffRow
+    class Cell
+      def initialize(key:, value:)
+        @key = key
+        @value = value
+      end
+
+      def cell_values
+        [
+          [key, value],
+          ["#{key}_sparql", sparql_value],
+          ["#{key}_csv", csv_value]
+        ]
+      end
+
+      private
+
+      attr_reader :key, :value
+    end
+
+    class CellAdded < Cell
+      def sparql_value
+        nil
+      end
+
+      def csv_value
+        value
+      end
+    end
+
+    class CellRemoved < Cell
+      def sparql_value
+        value
+      end
+
+      def csv_value
+        nil
+      end
+    end
+
+    class CellModified < Cell
+      def sparql_value
+        split_value.first
+      end
+
+      def csv_value
+        split_value.last
+      end
+
+      private
+
+      def split_value
+        value.split('->', 2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds additional template parameters that are passed to the custom row templates. If there's a `holder_id` parameter we now also pass in `holder_id_sparql` and `holder_id_wikidata` so that the template creator can inspect those values and act accordingly.

Fixes #51 