### PR TITLE
Use common headers from SPARQL and CSV

### DIFF
--- a/lib/compare_with_wikidata/membership_list/wikidata.rb
+++ b/lib/compare_with_wikidata/membership_list/wikidata.rb
@@ -12,7 +12,7 @@ module CompareWithWikidata
       end
 
       def to_a
-        @to_a ||= CSV.parse(sparql_response.to_s)
+        @to_a ||= CSV.parse(sparql_response.to_s, headers: true, header_converters: :symbol, converters: nil).map(&:to_h)
       end
 
       private


### PR DESCRIPTION
Rather than requiring the SPARQL and CSV to return exactly the same headers we simply check for common headers between the two sources and diff those.

Fixes #69 