### PR TITLE
Catch malformed CSV errors to provide a more helpful error message

### DIFF
--- a/compare_with_wikidata.gemspec
+++ b/compare_with_wikidata.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'rubocop', '~> 0.49'
+  spec.add_development_dependency 'webmock', '~> 3.0.0'
 end

--- a/lib/compare_with_wikidata.rb
+++ b/lib/compare_with_wikidata.rb
@@ -9,6 +9,9 @@ require 'erb'
 require 'mediawiki_api'
 
 module CompareWithWikidata
+  class MalformedCSVError < StandardError
+  end
+
   class DiffOutputGenerator
     WIKI_TEMPLATE_NAME = 'Compare Wikidata with CSV'.freeze
     WIKI_USERNAME = ENV['WIKI_USERNAME']
@@ -137,6 +140,8 @@ module CompareWithWikidata
 
     def csv_from_url(file_or_url)
       CSV.parse(RestClient.get(file_or_url).to_s, headers: true, header_converters: :symbol, converters: nil).map(&:to_h)
+    rescue CSV::MalformedCSVError
+      raise MalformedCSVError.new("The URL #{file_or_url} couldn't be parsed as CSV. Is it really a valid CSV file?")
     end
   end
 end

--- a/test/compare_with_wikidata_test.rb
+++ b/test/compare_with_wikidata_test.rb
@@ -4,4 +4,74 @@ describe 'CompareWithWikidata' do
   it 'has a version number' do
     ::CompareWithWikidata::VERSION.wont_be_nil
   end
+
+  describe 'DiffOutputGenerator' do
+    subject {
+      CompareWithWikidata::DiffOutputGenerator.new(
+        mediawiki_site: 'wikidata.example.com',
+        page_title: 'SomePage'
+      )
+    }
+
+    describe 'csv_from_url' do
+      it 'should produce a sensible response from genuine CSV' do
+        stub_request(:get, 'http://example.com/real.csv').to_return(
+          body: 'heading A,"heading B",heading C' "\r\n" \
+                '1,2,3' "\r\n"
+        )
+        result = subject.send(:csv_from_url, 'http://example.com/real.csv')
+        result.must_equal [
+          {heading_a: "1", heading_b: "2", heading_c: "3"}
+        ]
+      end
+
+      it 'should parse a minimal HTML document without commas or quotes as a single column' do
+        # This is a weird example, but some minimal valid HTML
+        # documents are also valid single column CSV files, and we
+        # should interpret them as such if possible:
+        stub_request(:get, 'http://example.com/html-but-also-valid-csv.csv').to_return(
+          body: '<!doctype html>
+<html lang=en>
+  <head>
+    <meta charset=utf-8>
+    <title>A minimal HTML document.</title>
+  </head>
+  <body><p></p>
+  </body>
+</html>
+')
+        result = subject.send(:csv_from_url, 'http://example.com/html-but-also-valid-csv.csv')
+        result.must_equal [
+          {:doctype_html=>"<html lang=en>"},
+          {:doctype_html=>"  <head>"},
+          {:doctype_html=>"    <meta charset=utf-8>"},
+          {:doctype_html=>"    <title>A minimal HTML document.</title>"},
+          {:doctype_html=>"  </head>"},
+          {:doctype_html=>"  <body><p></p>"},
+          {:doctype_html=>"  </body>"},
+          {:doctype_html=>"</html>"}
+        ]
+      end
+
+      it 'should raise an appropriate custom error on non-CSV containing mid-line quotes' do
+        # The quotes will cause the CSV reader to raise:
+        #   CSV::MalformedCSVError: Illegal quoting in line 5.
+        # ... which we should catch and turn into a more friendly
+        # error.
+        stub_request(:get, 'http://example.com/not-really-csv.csv').to_return(
+          body: '<!doctype html>
+<html lang=en>
+  <head>
+    <meta charset=utf-8>
+    <title>A minimal HTML that contains some "quotation marks".</title>
+  </head>
+</html>
+')
+        error = assert_raises CompareWithWikidata::MalformedCSVError do
+          subject.send(:csv_from_url, 'http://example.com/not-really-csv.csv')
+        end
+        error.message.must_equal "The URL http://example.com/not-really-csv.csv couldn't be parsed as CSV. Is it really a valid CSV file?"
+      end
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,3 +2,4 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'compare_with_wikidata'
 
 require 'minitest/autorun'
+require 'webmock/minitest'


### PR DESCRIPTION
If you accidentally supply a URL for something that isn't a valid CSV
file in the subpage that should have a URL for a CSV file, then the
error you get from the prompter tool is confusing - you'll just see
something like:

  "Error: Illegal quoting in line 8."

... with no hint about where that line is. The change introduced by this
commit catches malformed CSV errors and re-raise a new exception with a
more friendly message - something like:

  "The URL http://example.com/invalid.csv couldn't be parsed as CSV. Is it really a valid CSV file?"

Fixes #62
