### PR TITLE
Remove Wikidata URL prefix before diffing

### DIFF
--- a/lib/compare_with_wikidata/comparison.rb
+++ b/lib/compare_with_wikidata/comparison.rb
@@ -23,11 +23,15 @@ module CompareWithWikidata
     attr_reader :sparql_items, :csv_items, :columns
 
     def daff_sparql_items
-      [columns, *sparql_items.map { |r| r.values_at(*columns) }]
+      [columns, *sparql_items.map { |r| r.values_at(*columns).map { |c| cleaned_cell(c) } }]
     end
 
     def daff_csv_items
       [columns, *csv_items.map { |r| r.values_at(*columns) }]
+    end
+
+    def cleaned_cell(cell)
+      cell.to_s.sub(%r{^http://www.wikidata.org/entity/(Q\d+)$}, '\\1')
     end
 
     def daff_results

--- a/test/compare_with_wikidata/comparison_test.rb
+++ b/test/compare_with_wikidata/comparison_test.rb
@@ -1,25 +1,22 @@
 require 'test_helper'
 
 describe CompareWithWikidata::Comparison do
-  let(:sparql_items) { [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }] }
-  let(:csv_items) { [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }, { id: 3, name: 'Charlie' }] }
   subject { CompareWithWikidata::Comparison.new(sparql_items: sparql_items, csv_items: csv_items, columns: %i[id name]) }
 
-  describe '#headers' do
+  describe 'simple comparison' do
+    let(:sparql_items) { [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }] }
+    let(:csv_items) { [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }, { id: 3, name: 'Charlie' }] }
 
-    it 'returns the headers for the daff comparison' do
+    it 'has the expected headers' do
       subject.headers.must_equal ['@@', :id, :name]
     end
-  end
 
-  describe '#diff_rows' do
-    it 'returns the correct number of rows' do
+    it 'returns the correct number of diff_rows' do
       subject.diff_rows.size.must_equal 1
     end
 
-    it 'returns the expected number of DiffRow instances' do
-      row = subject.diff_rows.first
-      row.class.must_equal CompareWithWikidata::DiffRow
+    it 'returns DiffRow instances from diff_rows' do
+      subject.diff_rows.first.class.must_equal CompareWithWikidata::DiffRow
     end
   end
 end

--- a/test/compare_with_wikidata/comparison_test.rb
+++ b/test/compare_with_wikidata/comparison_test.rb
@@ -19,4 +19,19 @@ describe CompareWithWikidata::Comparison do
       subject.diff_rows.first.class.must_equal CompareWithWikidata::DiffRow
     end
   end
+
+  describe 'SPARQL items with Wikidata URL prefix' do
+    let(:sparql_items) do
+      [
+        { id: 'http://www.wikidata.org/entity/Q1' },
+        { id: 'http://www.wikidata.org/entity/Q2' },
+      ]
+    end
+
+    let(:csv_items) { [{ id: 'Q1' }, { id: 'Q2' }] }
+
+    it 'ignores the Wikidata URL prefix' do
+      subject.diff_rows.size.must_equal 0
+    end
+  end
 end


### PR DESCRIPTION
We want to remove any URL prefixes that are returned from the SPARQL query before running the comparison. This means the CSV file only needs to include Wikidata IDs, rather than full URLs.

# Notes to reviewer

The `cleaned_cell` method doesn't feel _quite_ right, but I think introducing a whole new `Cell` (or whatever) class just to strip the URL prefix seemed like a bit of an overkill. I'm open to any alternative suggestions though!

Fixes #65 