### PR TITLE
Make a /errors subpage reflect whether the last run errored

### DIFF
--- a/lib/compare_with_wikidata.rb
+++ b/lib/compare_with_wikidata.rb
@@ -88,7 +88,15 @@ module CompareWithWikidata
         end
       end
 
-      # Purge the main page, so it refreshes the subpages
+      # Apparently everything went smoothly, so overwrite the /errors
+      # subpage to make sure that it's empty.
+      client.edit(title: errors_page_title, text: '')
+
+    rescue StandardError => e
+      client.edit(title: errors_page_title, text: "<nowiki>#{e.message}</nowiki>")
+    ensure
+      # Purge the main page, so it refreshes the subpages, even if
+      # there was an exception.
       client.action(:purge, titles: [page_title])
     end
 
@@ -103,6 +111,10 @@ module CompareWithWikidata
           raise "MediawikiApi::Client#log_in failed: #{result}"
         end
       end
+    end
+
+    def errors_page_title
+      "#{page_title}/errors"
     end
 
     def expanded_wikitext(page_title)


### PR DESCRIPTION
This change catches any error which is a subclass of StandardError, and
stores it in a `/errors` subpage. If there was no error, it deletes all
content from the `/errors` subpage. This means that we can update the
"Compare Wikidata with CSV" template to display these errors in-page,
for example like:

![prompt-warning](https://user-images.githubusercontent.com/7907/29576381-814ea27c-875f-11e7-8232-dd4821c05d7d.png)

Part of the fix for #66 