### PR TITLE
Output unchanged columns from daff

### DIFF
--- a/lib/compare_with_wikidata/comparison.rb
+++ b/lib/compare_with_wikidata/comparison.rb
@@ -55,6 +55,7 @@ module CompareWithWikidata
       flags = Daff::CompareFlags.new
       # We don't want any context in the resulting diff
       flags.unchanged_context = 0
+      flags.show_unchanged_columns = true
       highlighter = Daff::TableDiff.new(alignment, flags)
       highlighter.hilite(table_diff)
 


### PR DESCRIPTION
If there are columns that contain no changes then we still want those to be returned by daff.

Without this flag daff replaces the unchanged column(s) with three dots (...), which leads to confusing prompt output.

Fixes #82 