### PR TITLE
Split up default and custom templates

### DIFF
--- a/lib/compare_with_wikidata.rb
+++ b/lib/compare_with_wikidata.rb
@@ -42,15 +42,12 @@ module CompareWithWikidata
       always_overwrite = {
         '/stats' => 'templates/stats.erb',
         '/comparison' => 'templates/comparison.erb',
-      }
-
-      overwrite_if_missing_or_empty = {
-        '/header_template' => 'templates/header_template.erb',
-        '/footer_template' => 'templates/footer_template.erb',
-        '/row_added_template' => 'templates/row_added.erb',
-        '/row_removed_template' => 'templates/row_removed.erb',
-        '/row_modified_template' => 'templates/row_modified.erb',
-        '/stats_template' => 'templates/stats_template.erb',
+        '/_default_header_template' => 'templates/header_template.erb',
+        '/_default_footer_template' => 'templates/footer_template.erb',
+        '/_default_row_added_template' => 'templates/row_added.erb',
+        '/_default_row_removed_template' => 'templates/row_removed.erb',
+        '/_default_row_modified_template' => 'templates/row_modified.erb',
+        '/_default_stats_template' => 'templates/stats_template.erb',
       }
 
       always_overwrite.each do |subpage, template|
@@ -63,29 +60,6 @@ module CompareWithWikidata
         else
           client.edit(title: title, text: wikitext)
           puts "Done: Updated #{title} on #{mediawiki_site}"
-        end
-      end
-
-      overwrite_if_missing_or_empty.each do |subpage, template|
-        template = ERB.new(File.read(File.join(__dir__, '..', template)), nil, '-')
-        please_edit = "<!-- Feel free to edit this template. If you want to get the default back just delete the contents of the page and then refresh the prompt. " \
-          "If you want this template to render nothing (e.g. to skip a row type) then delete everything except this comment. -->\n"
-        wikitext = please_edit + template.result(binding)
-        title = "#{page_title}#{subpage}"
-        result = client.get_wikitext(title)
-        if !result.success? || (result.success? && result.body.strip.empty?)
-          if ENV.key?('DEBUG')
-            puts "# #{title}\n#{wikitext}"
-          else
-            client.edit(title: title, text: wikitext)
-            puts "Done: Added default contents to #{title} on #{mediawiki_site}"
-          end
-        else
-          if ENV.key?('DEBUG')
-            puts "# #{title}\n#{result.body}"
-          else
-            puts "Page #{title} already exists"
-          end
         end
       end
 

--- a/lib/compare_with_wikidata/diff_row.rb
+++ b/lib/compare_with_wikidata/diff_row.rb
@@ -2,19 +2,21 @@ require 'compare_with_wikidata/diff_row/cell'
 
 module CompareWithWikidata
   class DiffRow
-    TEMPLATE_NAME_MAPPING = {
-      '+++' => '/row_added_template'.freeze,
-      '---' => '/row_removed_template'.freeze,
-      '->'  => '/row_modified_template'.freeze,
-    }.freeze
-
     def initialize(headers:, row:)
       @headers = headers
       @row = row
     end
 
-    def wikitext
-      "{{#{template_name}|#{template_params}}}"
+    def type
+      {
+        '+++' => 'row_added',
+        '---' => 'row_removed',
+        '->' => 'row_modified',
+      }[change_type]
+    end
+
+    def template_params
+      (change_type_cell + value_cells).map { |v| v.join('=') }.join('|')
     end
 
     def addition?
@@ -32,10 +34,6 @@ module CompareWithWikidata
     private
 
     attr_reader :headers, :row
-
-    def template_name
-      TEMPLATE_NAME_MAPPING[change_type]
-    end
 
     def row_as_hash
       headers.zip(row).to_h
@@ -55,10 +53,6 @@ module CompareWithWikidata
       else
         raise "Unknown change type: #{change_type}"
       end
-    end
-
-    def template_params
-      (change_type_cell + value_cells).map { |v| v.join('=') }.join('|')
     end
 
     def change_type_cell

--- a/templates/comparison.erb
+++ b/templates/comparison.erb
@@ -2,7 +2,22 @@
 Please see the [[../|main prompt page]].
 </noinclude>
 <includeonly>
-{{/header_template}}
-<%= comparison.diff_rows.map(&:wikitext).join("\n") %>
-{{/footer_template}}
+
+{{#if: {{/header_template}}
+| {{/header_template}}
+| {{/_default_header_template}}
+}}
+
+<% comparison.diff_rows.each do |row| %>
+{{#if: {{/<%= row.type %>_template|<%= row.template_params %>}}
+| {{/<%= row.type %>_template|<%= row.template_params %>}}
+| {{/_default_<%= row.type %>_template|<%= row.template_params %>}}
+}}
+<% end %>
+
+{{#if: {{/footer_template}}
+| {{/footer_template}}
+| {{/_default_footer_template}}
+}}
+
 </includeonly>

--- a/templates/stats.erb
+++ b/templates/stats.erb
@@ -1,7 +1,18 @@
+{{#if: {{/stats_template}}
+|
 {{/stats_template
 | removed=<%= comparison.diff_rows.count(&:removal?) %>
 | added=<%= comparison.diff_rows.count(&:addition?) %>
 | modified=<%= comparison.diff_rows.count(&:modification?) %>
 | sparql_count=<%= wikidata_records.size %>
 | csv_count=<%= external_csv.size %>
+}}
+|
+{{/_default_stats_template
+| removed=<%= comparison.diff_rows.count(&:removal?) %>
+| added=<%= comparison.diff_rows.count(&:addition?) %>
+| modified=<%= comparison.diff_rows.count(&:modification?) %>
+| sparql_count=<%= wikidata_records.size %>
+| csv_count=<%= external_csv.size %>
+}}
 }}


### PR DESCRIPTION
Write the default templates out _every time_ the prompt is refreshed. Then check for a custom template and if it's missing or empty then fallback to the default template.

This means that adding or removing columns will be reflected in the default templates. It also keeps the existing behaviour of blanking a template to go back to the default, but is now doing this check in Wikidata, rather than in Ruby.

The only drawback to this approach is that the "edit the header template" type links will be red initially, so the user won't be able to simply edit the default. I think we can possibly remedy that by having an **Install default templates** button which copies the default templates into the custom paths.

Fixes #73 