### PR TITLE
Check that custom templates exist before rendering

### DIFF
--- a/templates/comparison.erb
+++ b/templates/comparison.erb
@@ -3,20 +3,29 @@ Please see the [[../|main prompt page]].
 </noinclude>
 <includeonly>
 
-{{#if: {{/header_template}}
-| {{/header_template}}
+{{#ifexist: /header_template
+| {{#if: {{/header_template}}
+  | {{/header_template}}
+  | {{/_default_header_template}}
+  }}
 | {{/_default_header_template}}
 }}
 
 <% comparison.diff_rows.each do |row| %>
-{{#if: {{/<%= row.type %>_template|<%= row.template_params %>}}
-| {{/<%= row.type %>_template|<%= row.template_params %>}}
+{{#ifexist: /<%= row.type %>_template
+| {{#if: {{/<%= row.type %>_template|<%= row.template_params %>}}
+  | {{/<%= row.type %>_template|<%= row.template_params %>}}
+  | {{/_default_<%= row.type %>_template|<%= row.template_params %>}}
+  }}
 | {{/_default_<%= row.type %>_template|<%= row.template_params %>}}
 }}
 <% end %>
 
-{{#if: {{/footer_template}}
-| {{/footer_template}}
+{{#ifexist: /footer_template
+| {{#if: {{/footer_template}}
+  | {{/footer_template}}
+  | {{/_default_footer_template}}
+  }}
 | {{/_default_footer_template}}
 }}
 

--- a/templates/stats.erb
+++ b/templates/stats.erb
@@ -1,18 +1,25 @@
-{{#if: {{/stats_template}}
-|
-{{/stats_template
-| removed=<%= comparison.diff_rows.count(&:removal?) %>
-| added=<%= comparison.diff_rows.count(&:addition?) %>
-| modified=<%= comparison.diff_rows.count(&:modification?) %>
-| sparql_count=<%= wikidata_records.size %>
-| csv_count=<%= external_csv.size %>
-}}
-|
-{{/_default_stats_template
-| removed=<%= comparison.diff_rows.count(&:removal?) %>
-| added=<%= comparison.diff_rows.count(&:addition?) %>
-| modified=<%= comparison.diff_rows.count(&:modification?) %>
-| sparql_count=<%= wikidata_records.size %>
-| csv_count=<%= external_csv.size %>
-}}
+{{#ifexist: /stats_template
+| {{#if: {{/stats_template}}
+  | {{/stats_template
+    | removed=<%= comparison.diff_rows.count(&:removal?) %>
+    | added=<%= comparison.diff_rows.count(&:addition?) %>
+    | modified=<%= comparison.diff_rows.count(&:modification?) %>
+    | sparql_count=<%= wikidata_records.size %>
+    | csv_count=<%= external_csv.size %>
+    }}
+  | {{/_default_stats_template
+    | removed=<%= comparison.diff_rows.count(&:removal?) %>
+    | added=<%= comparison.diff_rows.count(&:addition?) %>
+    | modified=<%= comparison.diff_rows.count(&:modification?) %>
+    | sparql_count=<%= wikidata_records.size %>
+    | csv_count=<%= external_csv.size %>
+    }}
+  }}
+| {{/_default_stats_template
+  | removed=<%= comparison.diff_rows.count(&:removal?) %>
+  | added=<%= comparison.diff_rows.count(&:addition?) %>
+  | modified=<%= comparison.diff_rows.count(&:modification?) %>
+  | sparql_count=<%= wikidata_records.size %>
+  | csv_count=<%= external_csv.size %>
+  }}
 }}


### PR DESCRIPTION
We were previously checking if the default templates returned any contents using `#if`, but that doesn't handle templates that don't exist, because they do actually return contents: a red link to create the missing page.

This change adds an extra `#ifexist` check to ensure the template exists before we render it.

Fixes #87 