### PR TITLE
Make comparison page viewable directly

### DIFF
--- a/templates/comparison.erb
+++ b/templates/comparison.erb
@@ -1,32 +1,23 @@
-<noinclude>
-Please see the [[../|main prompt page]].
-</noinclude>
-<includeonly>
-
-{{#ifexist: /header_template
-| {{#if: {{/header_template}}
-  | {{/header_template}}
-  | {{/_default_header_template}}
+{{#ifexist: <%= page_title %>/header_template
+| {{#if: {{<%= page_title %>/header_template}}
+  | {{<%= page_title %>/header_template}}
+  | {{<%= page_title %>/_default_header_template}}
   }}
-| {{/_default_header_template}}
+| {{<%= page_title %>/_default_header_template}}
 }}
-
 <% comparison.diff_rows.each do |row| %>
-{{#ifexist: /<%= row.type %>_template
-| {{#if: {{/<%= row.type %>_template|<%= row.template_params %>}}
-  | {{/<%= row.type %>_template|<%= row.template_params %>}}
-  | {{/_default_<%= row.type %>_template|<%= row.template_params %>}}
+{{#ifexist: <%= page_title %>/<%= row.type %>_template
+| {{#if: {{<%= page_title %>/<%= row.type %>_template|<%= row.template_params %>}}
+  | {{<%= page_title %>/<%= row.type %>_template|<%= row.template_params %>}}
+  | {{<%= page_title %>/_default_<%= row.type %>_template|<%= row.template_params %>}}
   }}
-| {{/_default_<%= row.type %>_template|<%= row.template_params %>}}
+| {{<%= page_title %>/_default_<%= row.type %>_template|<%= row.template_params %>}}
 }}
 <% end %>
-
-{{#ifexist: /footer_template
-| {{#if: {{/footer_template}}
-  | {{/footer_template}}
-  | {{/_default_footer_template}}
+{{#ifexist: <%= page_title %>/footer_template
+| {{#if: {{<%= page_title %>/footer_template}}
+  | {{<%= page_title %>/footer_template}}
+  | {{<%= page_title %>/_default_footer_template}}
   }}
-| {{/_default_footer_template}}
+| {{<%= page_title %>/_default_footer_template}}
 }}
-
-</includeonly>


### PR DESCRIPTION
Use the full template name, rather than a "relative" (in MediaWiki terms) path, so that the `/comparison` subpage of the prompt can be viewed by visiting that page.

This means that when people are watching the page they can just view the changes on their own. It also means you can go back through the history of the comparison page and view older versions of it.

You can see this in action on [User:Chris_Mytton/sandbox/prompts/Riigikogu/comparison](https://www.wikidata.org/w/index.php?title=User:Chris_Mytton/sandbox/prompts/Riigikogu/comparison&oldid=552199241).

<img width="1014" alt="screen shot 2017-09-05 at 13 57 35" src="https://user-images.githubusercontent.com/22996/30062200-336c6a60-9242-11e7-8229-b7f4a03b62e4.png">


Fixes #89 