### PR TITLE
Only match Q values if they span the whole cell

### DIFF
--- a/lib/compare_with_wikidata/diff_row.rb
+++ b/lib/compare_with_wikidata/diff_row.rb
@@ -62,7 +62,7 @@ module CompareWithWikidata
     def value_cells
       row_as_hash.drop(1).flat_map do |k, v|
         # Expand Wikidata IDs to templates.
-        value = v.to_s.sub('http://www.wikidata.org/entity/', '').gsub(/Q(\d+)/, '{{Q|\\1}}')
+        value = v.to_s.sub('http://www.wikidata.org/entity/', '').sub(/^Q(\d+)$/, '{{Q|\\1}}')
         cell_class.new(key: k, value: value).cell_values
       end
     end

--- a/test/compare_with_wikidata/diff_row_test.rb
+++ b/test/compare_with_wikidata/diff_row_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+describe CompareWithWikidata::DiffRow do
+  describe 'cells containing Q values' do
+    it 'replaces them if they span the entire cell' do
+      row = CompareWithWikidata::DiffRow.new(headers: %w[@@ name], row: %w[+++ Q42])
+      row.template_params.must_equal '@@=+++|name={{Q|42}}|name_sparql=|name_csv={{Q|42}}'
+    end
+
+    it "doesn't replace Q values that appear with other text in a cell" do
+      row = CompareWithWikidata::DiffRow.new(headers: %w[@@ name], row: ['+++', 'Douglas Adams (Q42)'])
+      row.template_params.must_equal '@@=+++|name=Douglas Adams (Q42)|name_sparql=|name_csv=Douglas Adams (Q42)'
+    end
+  end
+end


### PR DESCRIPTION
We want to replace values like "Q42" with the full template tag, like "{{Q|42}}", however this was being a bit over-eager and replacing things that weren't actually Wikidata IDs.

To avoid this problem I've changed the regex so that it only matches a Q value if it is the entire contents of the cell.

Fixes #92 