### PR TITLE
Normalize underscores to spaces to avoid spurious comparison diffs

### DIFF
--- a/lib/compare_with_wikidata.rb
+++ b/lib/compare_with_wikidata.rb
@@ -21,7 +21,7 @@ module CompareWithWikidata
 
     def initialize(mediawiki_site:, page_title:)
       @mediawiki_site = mediawiki_site
-      @page_title = page_title
+      @page_title = page_title.gsub('_', ' ')
     end
 
     def run!

--- a/test/compare_with_wikidata/diff_output_generator_test.rb
+++ b/test/compare_with_wikidata/diff_output_generator_test.rb
@@ -89,5 +89,23 @@ describe 'CompareWithWikidata' do
         error.message.must_equal "The URL http://example.com/not-really-csv.csv couldn't be parsed as CSV. Is it really a valid CSV file?"
       end
     end
+
+    describe 'on instantiation' do
+      it 'normalizes underscores to spaces in the page title' do
+        generator = CompareWithWikidata::DiffOutputGenerator.new(
+          mediawiki_site: 'wikidata.example.com',
+          page_title: 'Some_interesting_page'
+        )
+        generator.send(:page_title).must_equal 'Some interesting page'
+      end
+
+      it 'leaves spaces intact in the page title' do
+        generator = CompareWithWikidata::DiffOutputGenerator.new(
+          mediawiki_site: 'wikidata.example.com',
+          page_title: 'Some interesting page'
+        )
+        generator.send(:page_title).must_equal 'Some interesting page'
+      end
+    end
   end
 end


### PR DESCRIPTION
At the moment, when the prompt is refresh manually, the page_title
parameter will have underscores instead of any spaces. On the other hand
when it is invoked automatically, the page_title parameter has spaces in
it. This means that when you look at diffs in the version history of the
comparison subpage, you'll see spurious differences (spaces to
underscores) when mixing manual and automatic refreshes.

It seems more robust that the DiffOutputGenerator class normalizes the
page_title parameter to one of these forms so it's consistently dealing
with just one; I've chosen to normalize to spaces in this commit.