### PR TITLE
Use separate SPARQL and CSV values in default comparison view

### DIFF
--- a/templates/header_template.erb
+++ b/templates/header_template.erb
@@ -1,5 +1,7 @@
 {|class="wikitable sortable"
-<% comparison.headers.each do |header| -%>
-! <%= header %>
+! <%= comparison.headers.first %>
+<% comparison.headers.drop(1).each do |header| -%>
+! <%= header %> (SPARQL)
+! <%= header %> (CSV)
 <% end -%>
 |-

--- a/templates/row_added.erb
+++ b/templates/row_added.erb
@@ -1,4 +1,6 @@
 |-
-<% comparison.headers.each do |header| -%>
+| {{{<%= comparison.headers.first %>}}}
+<% comparison.headers.drop(1).each do |header| -%>
+|
 | {{{<%= header %>}}}
 <% end -%>

--- a/templates/row_modified.erb
+++ b/templates/row_modified.erb
@@ -1,4 +1,5 @@
 |-
-<% comparison.headers.each do |header| -%>
-| {{{<%= header %>}}}
+| {{{<%= comparison.headers.first %>}}}
+<% comparison.headers.drop(1).each do |header| -%>
+{{#ifeq: {{{<%= header %>_sparql}}} | {{{<%= header %>_csv}}} | <td colspan="2">{{{<%= header %>}}}</td> | <td style="background:#fdfbe5">{{{<%= header %>_sparql}}}</td><td style="background:#fdfbe5">{{{<%= header %>_csv}}}</td>}}
 <% end -%>

--- a/templates/row_removed.erb
+++ b/templates/row_removed.erb
@@ -1,4 +1,6 @@
 |-
-<% comparison.headers.each do |header| -%>
+| {{{<%= comparison.headers.first %>}}}
+<% comparison.headers.drop(1).each do |header| -%>
 | {{{<%= header %>}}}
+|
 <% end -%>


### PR DESCRIPTION
Rather than having a single column that attempts to show changes in values this instead splits out separate columns, one for the value in the SPARQL query and one for the value in the CSV.

This makes it more obvious where the values are coming from and how they're changing.

Fixes https://github.com/everypolitician/compare_with_wikidata/issues/80
Fixes https://github.com/everypolitician/compare_with_wikidata/issues/81

## Example

You can see this in action on this prompt comparison page:

[User:Chris_Mytton/sandbox/prompts/Pakistan_National_Assembly_EveryPolitician/comparison](https://www.wikidata.org/w/index.php?title=User:Chris_Mytton/sandbox/prompts/Pakistan_National_Assembly_EveryPolitician/comparison&oldid=571659142)

## Screenshot

<img width="1372" alt="screen shot 2017-10-03 at 08 59 04" src="https://user-images.githubusercontent.com/22996/31115628-ff3b8dd6-a81a-11e7-9187-2d446fb48684.png">