### PR TITLE
Write raw comparison CSV to Wikidata

### DIFF
--- a/lib/compare_with_wikidata.rb
+++ b/lib/compare_with_wikidata.rb
@@ -63,6 +63,8 @@ module CompareWithWikidata
         end
       end
 
+      client.edit(title: csv_page_title, text: comparison.to_csv)
+
       # Apparently everything went smoothly, so overwrite the /errors
       # subpage to make sure that it's empty.
       client.edit(title: errors_page_title, text: '')
@@ -91,6 +93,10 @@ module CompareWithWikidata
 
     def errors_page_title
       "#{page_title}/errors"
+    end
+
+    def csv_page_title
+      "#{page_title}/csv"
     end
 
     def expanded_wikitext(page_title)

--- a/lib/compare_with_wikidata.rb
+++ b/lib/compare_with_wikidata.rb
@@ -96,7 +96,7 @@ module CompareWithWikidata
     end
 
     def csv_page_title
-      "#{page_title}/csv"
+      "#{page_title}/comparison_csv"
     end
 
     def expanded_wikitext(page_title)

--- a/lib/compare_with_wikidata/comparison.rb
+++ b/lib/compare_with_wikidata/comparison.rb
@@ -1,6 +1,7 @@
 require 'compare_with_wikidata/diff_row'
 
 require 'daff'
+require 'csv'
 
 module CompareWithWikidata
   class Comparison
@@ -16,6 +17,13 @@ module CompareWithWikidata
 
     def diff_rows
       @diff_rows ||= rows.map { |row| DiffRow.new(headers: headers, row: row) }
+    end
+
+    def to_csv
+      CSV.generate do |csv|
+        csv << headers
+        rows.each { |row| csv << row }
+      end
     end
 
     private


### PR DESCRIPTION
A couple of times now I've wanted to get the information out of a prompt comparison table for use with QuickStatements or similar. Copying and pasting the HTML into vim to get the Q values out works, but isn't optimal.

This change adds a `/csv` subpage to the prompt so you can retrieve the raw CSV.

You can see it in action here:

https://www.wikidata.org/wiki/User:Chris_Mytton/prompts/Argentina/Chamber_of_Deputies/csv

## Notes

At the moment this doesn't render nicely in the Wikidata interface, since it's just raw CSV data, but perhaps that doesn't matter, as you can just edit the source and copy the CSV out. I'm opening this pull request to get feedback on whether this is a good idea and to see if anyone has any suggestions for improvements or alternatives.