### PR TITLE
Refactoring: move processing of cell values into a new CellValue class

### DIFF
--- a/lib/compare_with_wikidata/diff_row.rb
+++ b/lib/compare_with_wikidata/diff_row.rb
@@ -59,18 +59,9 @@ module CompareWithWikidata
       row_as_hash.take(1)
     end
 
-    # TODO: move this onto String or a suitable subclass
-    def templatize_if_item_id(string)
-      string.sub(/^Q(\d+)$/, '{{Q|\\1}}')
-    end
-
     def value_cells
       row_as_hash.drop(1).flat_map do |k, v|
-        value = v.to_s.sub('http://www.wikidata.org/entity/', '')
-        # Expand Wikidata item IDs to templated versions. (These might
-        # be on either side of a '->' if the cell represents a change.)
-        value = value.split('->').map { |e| templatize_if_item_id(e) }.join('->')
-        cell_class.new(key: k, value: value).cell_values
+        cell_class.new(key: k, value: v).cell_values
       end
     end
   end

--- a/lib/compare_with_wikidata/diff_row/cell.rb
+++ b/lib/compare_with_wikidata/diff_row/cell.rb
@@ -3,7 +3,7 @@ module CompareWithWikidata
     class Cell
       def initialize(key:, value:)
         @key = key
-        @value = value
+        @raw_value = value
       end
 
       def cell_values
@@ -16,7 +16,21 @@ module CompareWithWikidata
 
       private
 
-      attr_reader :key, :value
+      attr_reader :key, :raw_value
+
+      def value
+        # Expand Wikidata item IDs to templated versions. (These might
+        # be on either side of a '->' if the cell represents a change.)
+        #   TODO: handle that case separately in CellModified
+        raw_value.to_s.sub('http://www.wikidata.org/entity/', '')
+                 .split('->').map { |e| templatize_if_item_id(e) }.join('->')
+      end
+
+      # TODO: move this onto String or a suitable subclass
+      #  (possibly create a Value class to handle it)
+      def templatize_if_item_id(string)
+        string.sub(/^Q(\d+)$/, '{{Q|\\1}}')
+      end
     end
 
     class CellAdded < Cell

--- a/lib/compare_with_wikidata/diff_row/cell.rb
+++ b/lib/compare_with_wikidata/diff_row/cell.rb
@@ -59,13 +59,17 @@ module CompareWithWikidata
       end
 
       def value
-        [sparql_value, csv_value].join('->')
+        [sparql_value, csv_value].join(separator)
       end
 
       private
 
+      def separator
+        '->'
+      end
+
       def split_value
-        raw_value.split('->', 2)
+        raw_value.split(separator, 2)
       end
     end
   end


### PR DESCRIPTION
Rather than creating each Cell with an already processed version of its
contents, move the logic for manipulating the contents into the Cell class
instead.

This moves the logic to where it more rightly belongs, and makes it
easier for us to handle the CellModified case (where we can have
Wikidata IDs on either "side" of the change).