### PR TITLE
Preload 'pry' in test_helper

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'compare_with_wikidata'
 
+require 'pry'
 require 'minitest/autorun'
 require 'webmock/minitest'


### PR DESCRIPTION
When working with tests, it's often useful to drop into `pry` to examine
what's going on. Pre-loading `pry` makes it easier to do that without
also remembering to `require` it in a specific test, and then remove it
again later.

This is a common pattern across lots of our repos.