### PR TITLE
Add simple tests for Comparison#to_csv

### DIFF
--- a/test/compare_with_wikidata/comparison_test.rb
+++ b/test/compare_with_wikidata/comparison_test.rb
@@ -18,6 +18,12 @@ describe CompareWithWikidata::Comparison do
     it 'returns DiffRow instances from diff_rows' do
       subject.diff_rows.first.class.must_equal CompareWithWikidata::DiffRow
     end
+
+    it 'constructs a CSV with the one difference' do
+      subject.to_csv.lines.count.must_equal 2
+      subject.to_csv.lines.first.must_equal "@@,id,name\n"
+      subject.to_csv.lines.last.must_equal "+++,3,Charlie\n"
+    end
   end
 
   describe 'SPARQL items with Wikidata URL prefix' do
@@ -32,6 +38,11 @@ describe CompareWithWikidata::Comparison do
 
     it 'ignores the Wikidata URL prefix' do
       subject.diff_rows.size.must_equal 0
+    end
+
+    it 'constructs a CSV with no differences rows' do
+      subject.to_csv.lines.count.must_equal 1
+      subject.to_csv.lines.first.must_equal "@@,id,name\n"
     end
   end
 end


### PR DESCRIPTION
There may be edge cases or other variations on this we want to add
later, but this makes sure that we at least have _some_ coverage of the
method.

Closes #110 

## Note to Reviewer

I was initially a little surprised that the CSV generated in the second case had a `name` header, as the test data only uses `id`. But this is because the `subject` [defined at line 4](https://github.com/everypolitician/compare_with_wikidata/blob/c329e6493b/test/compare_with_wikidata/comparison_test.rb#L4) explicitly sets the columns for both groups of tests. I suspect that each group should really have its own `subject` defined, but changing that seems like something that should really happen in a different PR.

