### PR TITLE
Re-enable `ensure-regression-tests`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ rvm:
 before_install: gem install bundler -v 1.15.4
 script:
   - bundle exec rake
-  # - bash <(curl -fsSL https://github.com/everypolitician/ensure-regression-tests/raw/master/ensure-regression-tests)
+  - bash <(curl -fsSL https://github.com/everypolitician/ensure-regression-tests/raw/master/ensure-regression-tests)


### PR DESCRIPTION
These were turned on in ec197f48, but then turned back off again
(without explanation) in a3e42656. As it's not clear why we *wouldn't*
want them, and we've had code sneak through untested, turn them back on
again.