### PR TITLE
Make 'reek' available

### DIFF
--- a/compare_with_wikidata.gemspec
+++ b/compare_with_wikidata.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'pry', '~> 0.10'
+  spec.add_development_dependency 'reek'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop', '~> 0.49'
   spec.add_development_dependency 'webmock', '~> 3.0.0'


### PR DESCRIPTION
We have too many problems with the existing code to turn on any
automatic checking yet, but adding this as a development dependency at
least lets us see what it would alert us to when adding new code, and we
can work separately on cleaning up the historic issues.

I'd like us to generate a "TODO" config from existing issues quite soon,
so that it can at least ensure we're moving in the right direction when
we make changes, but as we're currently more in clean-up mode than
new-functionality mode, it's probably better to leave them all out in
the open for a while first.