### PR TITLE
Refactor DiffOutputGenerator#comparison method

### DIFF
--- a/lib/compare_with_wikidata.rb
+++ b/lib/compare_with_wikidata.rb
@@ -118,14 +118,14 @@ module CompareWithWikidata
     end
 
     def comparison
-      return @comparison if @comparison
+      @comparison ||= begin
+        common_headers = wikidata_records.first.keys & external_csv.first.keys
+        if common_headers.empty?
+          raise 'There are no common columns between the two sources. Please ensure the SPARQL and CSV share at least one common column.'
+        end
 
-      common_headers = wikidata_records.first.keys & external_csv.first.keys
-      if common_headers.empty?
-        raise 'There are no common columns between the two sources. Please ensure the SPARQL and CSV share at least one common column.'
+        Comparison.new(sparql_items: wikidata_records, csv_items: external_csv, columns: common_headers)
       end
-
-      @comparison = Comparison.new(sparql_items: wikidata_records, csv_items: external_csv, columns: common_headers)
     end
   end
 end


### PR DESCRIPTION
This fixes an error which was being reported by reek. The refactoring also makes the `#comparison` method a bit more idiomatic.

The full error from reek was:

    [17]:InstanceVariableAssumption: CompareWithWikidata::DiffOutputGenerator assumes too much for instance variable '@comparison' [https://github.com/troessner/reek/blob/master/docs/Instance-Variable-Assumption.md]

https://github.com/troessner/reek/blob/master/docs/Instance-Variable-Assumption.md