### PR TITLE
Add simplecov for test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
+### Test coverage
+
+When you run the tests with `rake test` a coverage report is automatically generated in the `coverage/` directory in the root of the project. Open `coverage/index.html` in a browser to view the coverage report.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/chrismytton/compare_with_wikidata.

--- a/compare_with_wikidata.gemspec
+++ b/compare_with_wikidata.gemspec
@@ -28,5 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'reek'
   spec.add_development_dependency 'rubocop', '~> 0.49'
+  spec.add_development_dependency 'simplecov', '~> 0.16'
   spec.add_development_dependency 'webmock', '~> 3.0.0'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start
+
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'compare_with_wikidata'
 


### PR DESCRIPTION
This adds simplecov dependency and configuration, which will allow us to see the current test coverage for the library.

Fixes #124 