### PR TITLE
Fix rendering of cells with blank value

### DIFF
--- a/lib/compare_with_wikidata/diff_row/cell.rb
+++ b/lib/compare_with_wikidata/diff_row/cell.rb
@@ -23,10 +23,18 @@ module CompareWithWikidata
       end
     end
 
-    class CellValue < String
-      def templatized
-        sub('http://www.wikidata.org/entity/', '').sub(/^Q(\d+)$/, '{{Q|\\1}}')
+    class CellValue
+      def initialize(value)
+        @value = value
       end
+
+      def templatized
+        value.sub('http://www.wikidata.org/entity/', '').sub(/^Q(\d+)$/, '{{Q|\\1}}') if value
+      end
+
+      private
+
+      attr_reader :value
     end
 
     class CellAdded < Cell
@@ -59,7 +67,7 @@ module CompareWithWikidata
       end
 
       def value
-        [sparql_value, csv_value].join(separator)
+        [sparql_value, csv_value].compact.join(separator)
       end
 
       private

--- a/test/compare_with_wikidata/diff_row_test.rb
+++ b/test/compare_with_wikidata/diff_row_test.rb
@@ -26,5 +26,10 @@ describe CompareWithWikidata::DiffRow do
       row = CompareWithWikidata::DiffRow.new(headers: %w[@@ item], row: ['->', 'NULL->Q1572486'])
       row.template_params.must_equal '@@=->|item=NULL->{{Q|1572486}}|item_sparql=NULL|item_csv={{Q|1572486}}'
     end
+
+    it 'handles cells with a blank value' do
+      row = CompareWithWikidata::DiffRow.new(headers: %w[@@ start_date], row: ['->', ''])
+      row.template_params.must_equal '@@=->|start_date=|start_date_sparql=|start_date_csv='
+    end
   end
 end


### PR DESCRIPTION
There was an uncaught regression introduced when the `CellValue` class was added that meant cells with an empty string were causing an error because `nil` was being passed to the `CellValue` constructor, which causes an error because it inherits from `String`.

This change fixes that by making `CellValue` a plain class. As an added bonus this also clears up a reek warning about [inheriting from core classes](https://github.com/troessner/reek/blob/master/docs/Subclassed-From-Core-Class.md).

Fixes #127 