### PR TITLE
Use the bot flag on edits made by the bot user

### DIFF
--- a/lib/compare_with_wikidata.rb
+++ b/lib/compare_with_wikidata.rb
@@ -73,9 +73,13 @@ module CompareWithWikidata
 
     def client
       abort 'Please set WIKI_USERNAME and WIKI_PASSWORD' if WIKI_USERNAME.to_s.empty? || WIKI_PASSWORD.to_s.empty?
-      @client ||= MediawikiApi::Client.new("https://#{mediawiki_site}/w/api.php").tap do |c|
-        result = c.log_in(WIKI_USERNAME, WIKI_PASSWORD)
-        raise "MediawikiApi::Client#log_in failed: #{result}" unless result['result'] == 'Success'
+      @client ||= CompareWithWikidata::MediawikiAPIClient.new(
+        mediawiki_site: mediawiki_site,
+        username:       WIKI_USERNAME,
+        password:       WIKI_PASSWORD
+      ).tap do |c|
+        result = c.log_in
+        raise "MediawikiAPIClient#log_in failed: #{result}" unless result['result'] == 'Success'
       end
     end
 

--- a/lib/compare_with_wikidata.rb
+++ b/lib/compare_with_wikidata.rb
@@ -2,6 +2,7 @@ require 'compare_with_wikidata/version'
 
 require 'compare_with_wikidata/membership_list/wikidata'
 require 'compare_with_wikidata/comparison'
+require 'compare_with_wikidata/mediawiki_api_client'
 
 require 'csv'
 require 'erb'

--- a/lib/compare_with_wikidata/mediawiki_api_client.rb
+++ b/lib/compare_with_wikidata/mediawiki_api_client.rb
@@ -1,0 +1,41 @@
+module CompareWithWikidata
+  class MediawikiAPIClient
+    extend Forwardable
+
+    def initialize(mediawiki_site:, username:, password:, client: nil)
+      @mediawiki_site = mediawiki_site
+      @username = username
+      @password = password
+      @client = client
+    end
+
+    def_delegators :@client, :action, :get_wikitext
+
+    def edit(params)
+      return client.edit(params) unless username == bot_username
+      # Note that the value of the bot parameter isn't important - the
+      # parameter just has to be present:
+      # https://www.wikidata.org/w/api.php?action=help&modules=main#main/datatypes
+      client.edit(params.merge(bot: 'true'))
+    end
+
+    def log_in
+      client.log_in(username, password)
+    end
+
+    private
+
+    attr_reader :mediawiki_site, :username, :password
+
+    def client
+      @client ||= MediawikiApi::Client.new("https://#{mediawiki_site}/w/api.php").tap do |c|
+        result = c.log_in(username, password)
+        raise "MediawikiApi::Client#log_in failed: #{result}" unless result['result'] == 'Success'
+      end
+    end
+
+    def bot_username
+      ENV.fetch('BOT_USERNAME', 'Prompter Bot')
+    end
+  end
+end

--- a/test/compare_with_wikidata/mediawiki_api_client_test.rb
+++ b/test/compare_with_wikidata/mediawiki_api_client_test.rb
@@ -1,0 +1,111 @@
+require 'test_helper'
+
+describe CompareWithWikidata::MediawikiAPIClient do
+  it 'should delegate get_wikitext' do
+    mock_wrapped_client = MiniTest::Mock.new
+    mock_wrapped_client.expect(:get_wikitext, 'some result', ['Example Page Title'])
+    client = CompareWithWikidata::MediawikiAPIClient.new(
+      username: nil, password: nil, mediawiki_site: nil, client: mock_wrapped_client
+    )
+    client.get_wikitext('Example Page Title').must_equal 'some result'
+    mock_wrapped_client.verify
+  end
+
+  it 'should delegate action' do
+    mock_wrapped_client = MiniTest::Mock.new
+    mock_wrapped_client.expect(:action, 'results of purging', [:purge, titles: ['Example Page Title']])
+    client = CompareWithWikidata::MediawikiAPIClient.new(
+      username: nil, password: nil, mediawiki_site: nil, client: mock_wrapped_client
+    )
+    client.action(:purge, titles: ['Example Page Title']).must_equal 'results of purging'
+    mock_wrapped_client.verify
+  end
+
+  it 'should log_in with the encapsulated username and password' do
+    mock_wrapped_client = MiniTest::Mock.new
+    mock_wrapped_client.expect(:log_in, 'login results', %w[alice 1234])
+    client = CompareWithWikidata::MediawikiAPIClient.new(
+      username: 'alice', password: '1234', mediawiki_site: nil, client: mock_wrapped_client
+    )
+    client.log_in
+    mock_wrapped_client.verify
+  end
+
+  describe 'if the bot username has been specified in the environment' do
+    before do
+      @old_bot_username = ENV['BOT_USERNAME']
+      ENV['BOT_USERNAME'] = 'Another_Bot_User'
+    end
+
+    after do
+      ENV['BOT_USERNAME'] = @old_bot_username if @old_bot_username
+    end
+
+    it 'should use the bot flag for edits if the username matches BOT_USERNAME' do
+      mock_wrapped_client = MiniTest::Mock.new
+      mock_wrapped_client.expect(:edit, nil, [{ title: 'Foo', text: '== hello ==', bot: 'true' }])
+      client = CompareWithWikidata::MediawikiAPIClient.new(
+        username:       'Another_Bot_User',
+        password:       nil,
+        mediawiki_site: 'wikidata.example.com',
+        client:         mock_wrapped_client
+      )
+      client.edit(title: 'Foo', text: '== hello ==')
+      mock_wrapped_client.verify
+    end
+
+    it 'should not use the bot flag for edits if the username does not match BOT_USERNAME' do
+      mock_wrapped_client = MiniTest::Mock.new
+      mock_wrapped_client.expect(:edit, nil, [{ title: 'Foo', text: '== hello ==' }])
+      client = CompareWithWikidata::MediawikiAPIClient.new(
+        username:       'Not_A_Bot',
+        password:       nil,
+        mediawiki_site: 'wikidata.example.com',
+        client:         mock_wrapped_client
+      )
+      client.edit(title: 'Foo', text: '== hello ==')
+      mock_wrapped_client.verify
+    end
+  end
+
+  describe 'if the bot username is not specified in the environment' do
+    before do
+      @old_bot_username = ENV['BOT_USERNAME']
+      ENV.delete('BOT_USERNAME')
+    end
+
+    after do
+      ENV['BOT_USERNAME'] = @old_bot_username if @old_bot_username
+    end
+
+    describe 'if the username is not special' do
+      it 'should not use the bot flag for edits' do
+        mock_wrapped_client = MiniTest::Mock.new
+        mock_wrapped_client.expect(:edit, nil, [{ title: 'Foo', text: '== hello ==' }])
+        client = CompareWithWikidata::MediawikiAPIClient.new(
+          username:       'Some User',
+          password:       nil,
+          mediawiki_site: 'wikidata.example.com',
+          client:         mock_wrapped_client
+        )
+        client.edit(title: 'Foo', text: '== hello ==')
+        mock_wrapped_client.verify
+      end
+    end
+
+    describe 'if the username is the default bot username' do
+      it 'should use the bot flag for edits' do
+        mock_wrapped_client = MiniTest::Mock.new
+        mock_wrapped_client.expect(:edit, nil, [{ title: 'Foo', text: '== hello ==', bot: 'true' }])
+        client = CompareWithWikidata::MediawikiAPIClient.new(
+          username:       'Prompter Bot',
+          password:       nil,
+          mediawiki_site: 'wikidata.example.com',
+          client:         mock_wrapped_client
+        )
+        client.edit(title: 'Foo', text: '== hello ==')
+        mock_wrapped_client.verify
+      end
+    end
+  end
+end


### PR DESCRIPTION
We've had a problem reported with edits made by this tool: the Prompter
Bot account, which edits are made by in the production deployment, has
a bot flag for the account, but isn't setting the bot flag on the edits it
makes:

  https://www.wikidata.org/wiki/User_talk:Chris_Mytton#Bot_flag

This pull request looks at the username of the account the edit is being
made under, and will add the bot flag to edits when the username is
'Prompter Bot' (overridable with the `BOT_USERNAME` environment
variable).

This doesn't deal with refactoring the `run!` method of
`DiffOutputGenerator` or testing that the new proxy client class is used
by that method, because we've established that such refactoring (and
getting `run!` under test) is a larger task, and we should be dealing with
this user complaint as promptly as we can. It does have unit tests for
the proxy client class however.

Having run this manually from the command line using the "Prompter Bot"
account, this view shows that the edits do have the bot flag (see the bold
`b` beside two of the Prompter Bot edits:

https://www.wikidata.org/w/index.php?hidecategorization=1&target=User%3AMhl20%2Fprompts%2FRiigikogu&namespace=2&limit=50&days=30&enhanced=1&damaging__likelybad_color=c4&damaging__verylikelybad_color=c5&title=Special:RecentChangesLinked&urlversion=2

![bot-flag](https://user-images.githubusercontent.com/7907/39817510-43a57e60-5396-11e8-81d8-6a420673383c.png)
