### PR TITLE
Don't show unchanged values changing to themselves

### DIFF
--- a/lib/compare_with_wikidata/diff_row/cell.rb
+++ b/lib/compare_with_wikidata/diff_row/cell.rb
@@ -67,6 +67,7 @@ module CompareWithWikidata
       end
 
       def value
+        return sparql_value if sparql_value == csv_value
         [sparql_value, csv_value].compact.join(separator)
       end
 

--- a/test/compare_with_wikidata/comparison_test.rb
+++ b/test/compare_with_wikidata/comparison_test.rb
@@ -26,6 +26,29 @@ describe CompareWithWikidata::Comparison do
     end
   end
 
+  describe 'single column change' do
+    let(:sparql_items) { [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }] }
+    let(:csv_items) { [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bobby' }] }
+
+    it 'has the expected headers' do
+      subject.headers.must_equal ['@@', :id, :name]
+    end
+
+    it 'returns the correct number of diff_rows' do
+      subject.diff_rows.size.must_equal 1
+    end
+
+    it 'returns DiffRow instances from diff_rows' do
+      subject.diff_rows.first.class.must_equal CompareWithWikidata::DiffRow
+    end
+
+    it 'constructs a CSV with the one difference' do
+      subject.to_csv.lines.count.must_equal 2
+      subject.to_csv.lines.first.must_equal "@@,id,name\n"
+      subject.to_csv.lines.last.must_equal "->,2,Bob->Bobby\n"
+    end
+  end
+
   describe 'SPARQL items with Wikidata URL prefix' do
     let(:sparql_items) do
       [

--- a/test/compare_with_wikidata/diff_row_test.rb
+++ b/test/compare_with_wikidata/diff_row_test.rb
@@ -1,6 +1,18 @@
 require 'test_helper'
 
 describe CompareWithWikidata::DiffRow do
+  describe 'simple comparison' do
+    subject { CompareWithWikidata::DiffRow.new(headers: headers, row: row) }
+    let(:headers) { %w[@@ id name] }
+
+    describe 'when only the name changes' do
+      let(:row) { ['->', '2', 'Bob->Bobby'] }
+      it 'only has a change in a single cell' do
+        subject.template_params.must_equal '@@=->|id=2|id_sparql=2|id_csv=2|name=Bob->Bobby|name_sparql=Bob|name_csv=Bobby'
+      end
+    end
+  end
+
   describe 'cells containing Q values' do
     it 'replaces them if they span the entire cell' do
       row = CompareWithWikidata::DiffRow.new(headers: %w[@@ name], row: %w[+++ Q42])


### PR DESCRIPTION
https://github.com/everypolitician/compare_with_wikidata/pull/120 introduced a subtle regression, where, when one or more cells in a row have changed (and thus the row itself is marked as 'modified', a cell that was unchanged showed up as changing to itself.

Rather than showing an id, say, changing from "2->2", we should simply show the unchanged "2" as the value.

Closes https://github.com/everypolitician/compare_with_wikidata/issues/132

Tested on live data with https://www.wikidata.org/w/index.php?title=User%3AOravrattas%2Fprompts%2FScottish_Parliament%2Fcomparison&type=revision&diff=686716807&oldid=674024357:

Before:
![screen shot 2018-05-29 at 11 54 34](https://user-images.githubusercontent.com/57483/40654759-1f40ec52-6337-11e8-9efb-2ed781f7bcd4.png)

After:
![screen shot 2018-05-29 at 11 54 41](https://user-images.githubusercontent.com/57483/40654760-20e5dfcc-6337-11e8-9560-b62dd845d076.png)
