### PR TITLE
Don't splat keyword arguments as a single Hash

### DIFF
--- a/exe/compare_with_wikidata
+++ b/exe/compare_with_wikidata
@@ -18,5 +18,5 @@ options = URI.decode_www_form(query).map { |k, v| [k.to_sym, v] }.to_h
 
 warn "Running with options: #{options.inspect}" if ENV.key?('DEBUG')
 
-diff_output_generator = CompareWithWikidata::DiffOutputGenerator.new(**options)
+diff_output_generator = CompareWithWikidata::DiffOutputGenerator.new(options)
 diff_output_generator.run!


### PR DESCRIPTION
Ruby 2.6 is apparently going to start warning about this, and so Rubocop has introduced a check for it:
  https://github.com/bbatsov/rubocop/pull/5871/files

Fixes https://github.com/everypolitician/compare_with_wikidata/issues/134